### PR TITLE
Check that topic exists before fetching offsets

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -320,6 +320,14 @@ func (c *CLIRunner) GetGroupMembers(ctx context.Context, groupID string) error {
 func (c *CLIRunner) GetMemberLags(ctx context.Context, topic string, groupID string) error {
 	c.startSpinner()
 
+	// Check that topic exists before getting offsets; otherwise, the topic get
+	// created as part of the lag check.
+	_, err := c.adminClient.GetTopic(ctx, topic, false)
+	if err != nil {
+		c.stopSpinner()
+		return fmt.Errorf("Error fetching topic info: %+v", err)
+	}
+
 	memberLags, err := c.groupsClient.GetMemberLags(ctx, topic, groupID)
 	c.stopSpinner()
 
@@ -359,7 +367,7 @@ func (c *CLIRunner) GetOffsets(ctx context.Context, topic string) error {
 	c.startSpinner()
 
 	// Check that topic exists before getting offsets; otherwise, the topic might
-	// be created.
+	// be created as part of the bounds check.
 	_, err := c.adminClient.GetTopic(ctx, topic, false)
 	if err != nil {
 		c.stopSpinner()


### PR DESCRIPTION
## Description
This change update the `get offsets` and `get lags` subcommands to check that the topic exists before fetching any offsets. Based on some local testing, it looks like kafka-go might create the topic if it doesn't already exist when doing these checks, which we don't want.