### PR TITLE
Misc. usability improvements

### DIFF
--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -88,7 +88,7 @@ func init() {
 	applyCmd.Flags().StringVar(
 		&applyConfig.retentionDropStepDurationStr,
 		"retention-drop-step-duration",
-		os.Getenv("TOPICCTL_APPLY_RETENTION_DROP_STEP_DURATION"),
+		"",
 		"Amount of time to use for retention drop steps",
 	)
 	applyCmd.Flags().BoolVar(

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -32,8 +32,9 @@ type applyCmdConfig struct {
 	partitionBatchSizeOverride int
 	pathPrefix                 string
 	rebalance                  bool
+	retentionDropStepDuration  time.Duration
 	skipConfirm                bool
-	sleepLoopTime              time.Duration
+	sleepLoopDuration          time.Duration
 }
 
 var applyConfig applyCmdConfig
@@ -69,17 +70,23 @@ func init() {
 		0,
 		"Partition batch size override",
 	)
+	applyCmd.Flags().StringVar(
+		&applyConfig.pathPrefix,
+		"path-prefix",
+		os.Getenv("TOPICCTL_APPLY_PATH_PREFIX"),
+		"Prefix for topic config paths",
+	)
 	applyCmd.Flags().BoolVar(
 		&applyConfig.rebalance,
 		"rebalance",
 		false,
 		"Explicitly rebalance broker partition assignments",
 	)
-	applyCmd.Flags().StringVar(
-		&applyConfig.pathPrefix,
-		"path-prefix",
-		os.Getenv("TOPICCTL_APPLY_PATH_PREFIX"),
-		"Prefix for topic config paths",
+	applyCmd.Flags().DurationVar(
+		&applyConfig.retentionDropStepDuration,
+		"retention-drop-step-duration",
+		10*time.Hour,
+		"Amount of time to use for retention drop steps; set to 0 to remove limit",
 	)
 	applyCmd.Flags().BoolVar(
 		&applyConfig.skipConfirm,
@@ -88,8 +95,8 @@ func init() {
 		"Skip confirmation prompts during apply process",
 	)
 	applyCmd.Flags().DurationVar(
-		&applyConfig.sleepLoopTime,
-		"sleep-loop-time",
+		&applyConfig.sleepLoopDuration,
+		"sleep-loop-duration",
 		10*time.Second,
 		"Amount of time to wait between partition checks",
 	)
@@ -189,8 +196,9 @@ func applyTopic(
 		DryRun:                     applyConfig.dryRun,
 		PartitionBatchSizeOverride: applyConfig.partitionBatchSizeOverride,
 		Rebalance:                  applyConfig.rebalance,
+		RetentionDropStepDuration:  applyConfig.retentionDropStepDuration,
 		SkipConfirm:                applyConfig.skipConfirm,
-		SleepLoopTime:              applyConfig.sleepLoopTime,
+		SleepLoopDuration:          applyConfig.sleepLoopDuration,
 		TopicConfig:                topicConfig,
 	}
 

--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -153,7 +153,7 @@ func getRun(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Must provide topic and groupID as additional positional arguments")
 		}
 
-		return cliRunner.GetMemberLags(ctx, args[1], args[2])
+		return cliRunner.GetMemberLags(ctx, args[1], args[2], getConfig.full)
 	case "members":
 		if len(args) != 2 {
 			return fmt.Errorf("Must provide group ID as second positional argument")

--- a/examples/local-cluster/topics/topic-default.yaml
+++ b/examples/local-cluster/topics/topic-default.yaml
@@ -9,7 +9,7 @@ meta:
 spec:
   partitions: 3
   replicationFactor: 2
-  retentionMinutes: 50
+  retentionMinutes: 100
   placement:
     strategy: any
   settings:

--- a/examples/local-cluster/topics/topic-default.yaml
+++ b/examples/local-cluster/topics/topic-default.yaml
@@ -9,7 +9,7 @@ meta:
 spec:
   partitions: 3
   replicationFactor: 2
-  retentionMinutes: 100
+  retentionMinutes: 50
   placement:
     strategy: any
   settings:

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -356,9 +356,20 @@ func (t *TopicApplier) updateSettings(
 		return err
 	}
 
+	var retentionDropStepDuration time.Duration
+	if t.config.RetentionDropStepDuration != 0 {
+		retentionDropStepDuration = t.config.RetentionDropStepDuration
+	} else {
+		var err error
+		retentionDropStepDuration, err = t.config.ClusterConfig.GetDefaultRetentionDropStepDuration()
+		if err != nil {
+			return err
+		}
+	}
+
 	reduced, err := topicSettings.ReduceRetentionDrop(
 		topicInfo.Config,
-		t.config.RetentionDropStepDuration,
+		retentionDropStepDuration,
 	)
 	if err != nil {
 		return err

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -29,8 +30,9 @@ type TopicApplierConfig struct {
 	DryRun                     bool
 	PartitionBatchSizeOverride int
 	Rebalance                  bool
+	RetentionDropStepDuration  time.Duration
 	SkipConfirm                bool
-	SleepLoopTime              time.Duration
+	SleepLoopDuration          time.Duration
 	TopicConfig                config.TopicConfig
 }
 
@@ -168,7 +170,7 @@ func (t *TopicApplier) applyNewTopic(ctx context.Context) error {
 	}
 
 	// Just do a short sleep to ensure that zk is updated before we check
-	if err := interruptableSleep(ctx, t.config.SleepLoopTime/5); err != nil {
+	if err := interruptableSleep(ctx, t.config.SleepLoopDuration/5); err != nil {
 		return err
 	}
 
@@ -354,6 +356,14 @@ func (t *TopicApplier) updateSettings(
 		return err
 	}
 
+	reduced, err := topicSettings.ReduceRetentionDrop(
+		topicInfo.Config,
+		t.config.RetentionDropStepDuration,
+	)
+	if err != nil {
+		return err
+	}
+
 	if len(diffKeys) > 0 {
 		diffsTable, err := FormatSettingsDiff(topicSettings, topicInfo.Config, diffKeys)
 		if err != nil {
@@ -365,6 +375,18 @@ func (t *TopicApplier) updateSettings(
 			len(diffKeys),
 			diffsTable,
 		)
+
+		if reduced {
+			log.Infof(
+				strings.Join(
+					[]string{
+						"Note: Retention drop has been reduced to minimize cluster disruption.",
+						"Re-run apply afterwards to keep dropping retention to configured value or run with --retention-drop-step-duration=0 to not do gradual step-down.",
+					},
+					" ",
+				),
+			)
+		}
 
 		if t.config.DryRun {
 			log.Infof("Skipping update because dryRun is set to true")
@@ -887,7 +909,7 @@ func (t *TopicApplier) updatePartitionsIteration(
 		return err
 	}
 
-	checkTimer := time.NewTicker(t.config.SleepLoopTime)
+	checkTimer := time.NewTicker(t.config.SleepLoopDuration)
 	defer checkTimer.Stop()
 
 	log.Info("Sleeping then entering check loop")
@@ -945,7 +967,7 @@ outerLoop:
 				len(assignmentsToUpdate),
 				admin.FormatTopicPartitions(notReady, t.brokers),
 			)
-			log.Infof("Sleeping for %s", t.config.SleepLoopTime.String())
+			log.Infof("Sleeping for %s", t.config.SleepLoopDuration.String())
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -1181,7 +1203,7 @@ func (t *TopicApplier) updateLeadersIteration(
 		return err
 	}
 
-	checkTimer := time.NewTicker(t.config.SleepLoopTime)
+	checkTimer := time.NewTicker(t.config.SleepLoopDuration)
 	defer checkTimer.Stop()
 
 	log.Info("Sleeping then entering check loop")
@@ -1212,7 +1234,7 @@ outerLoop:
 				admin.FormatTopicPartitions(wrongLeaders, t.brokers),
 			)
 
-			log.Infof("Sleeping for %s", t.config.SleepLoopTime.String())
+			log.Infof("Sleeping for %s", t.config.SleepLoopDuration.String())
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/pkg/check/check_test.go
+++ b/pkg/check/check_test.go
@@ -58,11 +58,11 @@ func TestCheck(t *testing.T) {
 		ctx,
 		adminClient,
 		apply.TopicApplierConfig{
-			ClusterConfig: clusterConfig,
-			TopicConfig:   topicConfig,
-			DryRun:        false,
-			SkipConfirm:   true,
-			SleepLoopTime: 500 * time.Millisecond,
+			ClusterConfig:     clusterConfig,
+			TopicConfig:       topicConfig,
+			DryRun:            false,
+			SkipConfirm:       true,
+			SleepLoopDuration: 500 * time.Millisecond,
 		},
 	)
 	require.Nil(t, err)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -352,7 +352,12 @@ func (c *CLIRunner) GetGroupMembers(ctx context.Context, groupID string, full bo
 
 // GetMemberLags fetches and prints a summary of the consumer group lag for each partition
 // in a single topic.
-func (c *CLIRunner) GetMemberLags(ctx context.Context, topic string, groupID string) error {
+func (c *CLIRunner) GetMemberLags(
+	ctx context.Context,
+	topic string,
+	groupID string,
+	full bool,
+) error {
 	c.startSpinner()
 
 	// Check that topic exists before getting offsets; otherwise, the topic get
@@ -370,7 +375,7 @@ func (c *CLIRunner) GetMemberLags(ctx context.Context, topic string, groupID str
 		return err
 	}
 
-	c.printer("Group member lags:\n%s", groups.FormatMemberLags(memberLags))
+	c.printer("Group member lags:\n%s", groups.FormatMemberLags(memberLags, full))
 	return nil
 }
 

--- a/pkg/cli/repl.go
+++ b/pkg/cli/repl.go
@@ -262,7 +262,7 @@ func (r *Repl) executor(in string) {
 				log.Errorf("Error: %+v", err)
 				return
 			}
-			if err := r.cliRunner.GetMemberLags(ctx, words[2], words[3]); err != nil {
+			if err := r.cliRunner.GetMemberLags(ctx, words[2], words[3], false); err != nil {
 				log.Errorf("Error: %+v", err)
 				return
 			}

--- a/pkg/config/cluster_test.go
+++ b/pkg/config/cluster_test.go
@@ -24,9 +24,10 @@ func TestClusterValidate(t *testing.T) {
 					Description: "test-description",
 				},
 				Spec: ClusterSpec{
-					BootstrapAddrs: []string{"broker-addr"},
-					ZKAddrs:        []string{"zk-addr"},
-					VersionMajor:   "v2",
+					BootstrapAddrs:                      []string{"broker-addr"},
+					ZKAddrs:                             []string{"zk-addr"},
+					VersionMajor:                        "v2",
+					DefaultRetentionDropStepDurationStr: "5m",
 				},
 			},
 			expError: false,
@@ -74,6 +75,24 @@ func TestClusterValidate(t *testing.T) {
 				Spec: ClusterSpec{
 					BootstrapAddrs: []string{"broker-addr"},
 					VersionMajor:   "v2",
+				},
+			},
+			expError: true,
+		},
+		{
+			description: "bad retention drop format",
+			clusterConfig: ClusterConfig{
+				Meta: ClusterMeta{
+					Name:        "test-cluster",
+					Region:      "test-region",
+					Environment: "test-environment",
+					Description: "test-description",
+				},
+				Spec: ClusterSpec{
+					BootstrapAddrs:                      []string{"broker-addr"},
+					ZKAddrs:                             []string{"zk-addr"},
+					VersionMajor:                        "v2",
+					DefaultRetentionDropStepDurationStr: "10xxx",
 				},
 			},
 			expError: true,

--- a/pkg/groups/format.go
+++ b/pkg/groups/format.go
@@ -182,7 +182,7 @@ func FormatMemberPartitionCounts(members []MemberInfo) string {
 }
 
 // FormatMemberLags generates a pretty table from the results of GetMemberLags.
-func FormatMemberLags(memberLags []MemberPartitionLag) string {
+func FormatMemberLags(memberLags []MemberPartitionLag, full bool) string {
 	buf := &bytes.Buffer{}
 
 	table := tablewriter.NewWriter(buf)
@@ -198,7 +198,7 @@ func FormatMemberLags(memberLags []MemberPartitionLag) string {
 			"Time Lag",
 		},
 	)
-	table.SetAutoWrapText(false)
+	table.SetAutoWrapText(true)
 	table.SetColumnAlignment(
 		[]int{
 			tablewriter.ALIGN_LEFT,
@@ -224,7 +224,11 @@ func FormatMemberLags(memberLags []MemberPartitionLag) string {
 		var memberID string
 
 		if memberLag.MemberID != "" {
-			memberID, _ = util.TruncateStringMiddle(memberLag.MemberID, 30, 5)
+			if full {
+				memberID = memberLag.MemberID
+			} else {
+				memberID, _ = util.TruncateStringMiddle(memberLag.MemberID, 30, 5)
+			}
 		}
 
 		var memberIDPrinter func(f string, a ...interface{}) string


### PR DESCRIPTION
## Description
This change includes two, minor usability improvements based on user feedback:

1. Show full member IDs when running `get lags` with the `--full` flag
2. Optionally support a floor on retention reductions. If an apply run includes a topic retention time reduction beyond the limit set in `--retention-drop-step-duration`, then only reduce it down by that amount. To get the full retention reduction with this value set, the user is required to run apply multiple times. This value can also be set on a per-cluster basis by adding a `defaultRetentionDropStepDuration` value into the cluster spec.

The second is motivated by some issues we've had inside Segment when doing big retention reductions on large topics. It's off by default but might be useful in other settings.