### PR TITLE
Support sorting member lags by value

### DIFF
--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -35,6 +35,7 @@ var getCmd = &cobra.Command{
 type getCmdConfig struct {
 	clusterConfig string
 	full          bool
+	sortValues    bool
 	zkAddr        string
 	zkPrefix      string
 }
@@ -53,6 +54,12 @@ func init() {
 		"full",
 		false,
 		"Show more full information for resources",
+	)
+	getCmd.Flags().BoolVar(
+		&getConfig.sortValues,
+		"sort-values",
+		false,
+		"Sort by value instead of name; only applies for lags at the moment",
 	)
 	getCmd.Flags().StringVarP(
 		&getConfig.zkAddr,
@@ -153,7 +160,13 @@ func getRun(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Must provide topic and groupID as additional positional arguments")
 		}
 
-		return cliRunner.GetMemberLags(ctx, args[1], args[2], getConfig.full)
+		return cliRunner.GetMemberLags(
+			ctx,
+			args[1],
+			args[2],
+			getConfig.full,
+			getConfig.sortValues,
+		)
 	case "members":
 		if len(args) != 2 {
 			return fmt.Errorf("Must provide group ID as second positional argument")

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -357,6 +357,7 @@ func (c *CLIRunner) GetMemberLags(
 	topic string,
 	groupID string,
 	full bool,
+	sortByValues bool,
 ) error {
 	c.startSpinner()
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -376,7 +377,16 @@ func (c *CLIRunner) GetMemberLags(
 		return err
 	}
 
-	c.printer("Group member lags:\n%s", groups.FormatMemberLags(memberLags, full))
+	if sortByValues {
+		sort.Slice(memberLags, func(a, b int) bool {
+			return memberLags[a].TimeLag() < memberLags[b].TimeLag()
+		})
+	}
+
+	c.printer(
+		"Group member lags:\n%s",
+		groups.FormatMemberLags(memberLags, full),
+	)
 	return nil
 }
 

--- a/pkg/cli/command.go
+++ b/pkg/cli/command.go
@@ -1,0 +1,37 @@
+package cli
+
+import "strings"
+
+type cliCommand struct {
+	args  []string
+	flags map[string]string
+}
+
+// parse parses the CLI inputs into command args and flags.
+func parseInputs(input string) cliCommand {
+	args := []string{}
+	flags := map[string]string{}
+
+	components := strings.Split(input, " ")
+
+	for c, component := range components {
+		if component == "" {
+			continue
+		} else if c > 0 && strings.HasPrefix(component, "--") {
+			subcomponents := strings.SplitN(component, "=", 2)
+			key := subcomponents[0][2:]
+			var value string
+			if len(subcomponents) > 1 {
+				value = subcomponents[1]
+			}
+			flags[key] = value
+		} else {
+			args = append(args, component)
+		}
+	}
+
+	return cliCommand{
+		args:  args,
+		flags: flags,
+	}
+}

--- a/pkg/cli/command.go
+++ b/pkg/cli/command.go
@@ -7,6 +7,19 @@ type cliCommand struct {
 	flags map[string]string
 }
 
+func (c cliCommand) getBoolValue(key string) bool {
+	value, ok := c.flags[key]
+
+	if value == "true" {
+		return true
+	} else if value == "" && ok {
+		// If key is set but value is not, treat this as "true"
+		return true
+	} else {
+		return false
+	}
+}
+
 // parse parses the CLI inputs into command args and flags.
 func parseInputs(input string) cliCommand {
 	args := []string{}

--- a/pkg/cli/command.go
+++ b/pkg/cli/command.go
@@ -1,14 +1,17 @@
 package cli
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-type cliCommand struct {
+type replCommand struct {
 	args  []string
 	flags map[string]string
 }
 
-func (c cliCommand) getBoolValue(key string) bool {
-	value, ok := c.flags[key]
+func (r replCommand) getBoolValue(key string) bool {
+	value, ok := r.flags[key]
 
 	if value == "true" {
 		return true
@@ -20,8 +23,34 @@ func (c cliCommand) getBoolValue(key string) bool {
 	}
 }
 
-// parse parses the CLI inputs into command args and flags.
-func parseInputs(input string) cliCommand {
+func (r replCommand) checkArgs(
+	minArgs int,
+	maxArgs int,
+	allowedFlags map[string]struct{},
+) error {
+	if minArgs == maxArgs {
+		if len(r.args) != minArgs {
+			return fmt.Errorf("Expected %d args", minArgs)
+		}
+	} else {
+		if len(r.args) < minArgs || len(r.args) > maxArgs {
+			return fmt.Errorf("Expected between %d and %d args", minArgs, maxArgs)
+		}
+	}
+
+	for key := range r.flags {
+		if allowedFlags == nil {
+			return fmt.Errorf("Flag %s not recognized", key)
+		}
+		if _, ok := allowedFlags[key]; !ok {
+			return fmt.Errorf("Flag %s not recognized", key)
+		}
+	}
+
+	return nil
+}
+
+func parseReplInputs(input string) replCommand {
 	args := []string{}
 	flags := map[string]string{}
 
@@ -43,7 +72,7 @@ func parseInputs(input string) cliCommand {
 		}
 	}
 
-	return cliCommand{
+	return replCommand{
 		args:  args,
 		flags: flags,
 	}

--- a/pkg/cli/command_test.go
+++ b/pkg/cli/command_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	assert.Equal(
+		t,
+		cliCommand{
+			args:  []string{"arg1", "arg2"},
+			flags: map[string]string{},
+		},
+		parseInputs("arg1   arg2"),
+	)
+	assert.Equal(
+		t,
+		cliCommand{
+			args:  []string{"--flag1=value1", "arg1", "arg2"},
+			flags: map[string]string{},
+		},
+		parseInputs("--flag1=value1  arg1   arg2"),
+	)
+	assert.Equal(
+		t,
+		cliCommand{
+			args: []string{"arg1", "arg2", "arg3"},
+			flags: map[string]string{
+				"flag1": "value1",
+				"flag2": "value2",
+			},
+		},
+		parseInputs("arg1 arg2 --flag1=value1 arg3 --flag2=value2"),
+	)
+}

--- a/pkg/cli/command_test.go
+++ b/pkg/cli/command_test.go
@@ -6,38 +6,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParse(t *testing.T) {
+func TestParseReplInputs(t *testing.T) {
 	assert.Equal(
 		t,
-		cliCommand{
+		replCommand{
 			args:  []string{"arg1", "arg2"},
 			flags: map[string]string{},
 		},
-		parseInputs("arg1   arg2"),
+		parseReplInputs("arg1   arg2"),
 	)
 	assert.Equal(
 		t,
-		cliCommand{
+		replCommand{
 			args:  []string{"--flag1=value1", "arg1", "arg2"},
 			flags: map[string]string{},
 		},
-		parseInputs("--flag1=value1  arg1   arg2"),
+		parseReplInputs("--flag1=value1  arg1   arg2"),
 	)
 	assert.Equal(
 		t,
-		cliCommand{
+		replCommand{
 			args: []string{"arg1", "arg2", "arg3"},
 			flags: map[string]string{
 				"flag1": "value1",
 				"flag2": "value2",
 			},
 		},
-		parseInputs("arg1 arg2 --flag1=value1 arg3 --flag2=value2"),
+		parseReplInputs("arg1 arg2 --flag1=value1 arg3 --flag2=value2"),
 	)
 }
 
 func TestGetBoolValue(t *testing.T) {
-	command := cliCommand{
+	command := replCommand{
 		flags: map[string]string{
 			"key1": "",
 			"key2": "true",

--- a/pkg/cli/command_test.go
+++ b/pkg/cli/command_test.go
@@ -35,3 +35,17 @@ func TestParse(t *testing.T) {
 		parseInputs("arg1 arg2 --flag1=value1 arg3 --flag2=value2"),
 	)
 }
+
+func TestGetBoolValue(t *testing.T) {
+	command := cliCommand{
+		flags: map[string]string{
+			"key1": "",
+			"key2": "true",
+			"key3": "false",
+		},
+	}
+	assert.True(t, command.getBoolValue("key1"))
+	assert.True(t, command.getBoolValue("key2"))
+	assert.False(t, command.getBoolValue("key3"))
+	assert.False(t, command.getBoolValue("non-existent-key"))
+}

--- a/pkg/cli/command_test.go
+++ b/pkg/cli/command_test.go
@@ -49,3 +49,23 @@ func TestGetBoolValue(t *testing.T) {
 	assert.False(t, command.getBoolValue("key3"))
 	assert.False(t, command.getBoolValue("non-existent-key"))
 }
+
+func TestCheckArgs(t *testing.T) {
+	command := replCommand{
+		args: []string{
+			"arg1",
+			"arg2",
+		},
+		flags: map[string]string{
+			"key1": "value1",
+		},
+	}
+	assert.NoError(t, command.checkArgs(2, 2, map[string]struct{}{"key1": {}}))
+	assert.NoError(t, command.checkArgs(2, 3, map[string]struct{}{"key1": {}}))
+	assert.NoError(t, command.checkArgs(1, 2, map[string]struct{}{"key1": {}}))
+	assert.NoError(t, command.checkArgs(1, 2, map[string]struct{}{"key1": {}, "key2": {}}))
+	assert.Error(t, command.checkArgs(3, 3, map[string]struct{}{"key1": {}}))
+	assert.Error(t, command.checkArgs(3, 5, map[string]struct{}{"key1": {}}))
+	assert.Error(t, command.checkArgs(2, 2, map[string]struct{}{"key2": {}}))
+	assert.Error(t, command.checkArgs(2, 2, nil))
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current topicctl version.
-const Version = "0.0.3"
+const Version = "0.0.4"


### PR DESCRIPTION
## Description
This change updates `topicctl get lags` to support sorting the lags by value. The latter is useful when trying to figure out which member partitions are lagging in a large topic.

This change also updates the repl mode to support optional flags so that users can adjust lag sorting and other things directly  without having to use a non-interactive command for these.

## Testing
Testing completed successfully via installing locally, verifying that new options worked correctly when hitting a kafka cluster.