### PR TITLE
Fix describegroups implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test010:
     working_directory: /go/src/github.com/segmentio/topicctl
     docker:
-      - image: circleci/golang:1.16
+      - image: circleci/golang:1.17
         environment:
           GO111MODULE: "on"
           ECR_ENABLED: True
@@ -105,7 +105,7 @@ jobs:
   test241:
     working_directory: /go/src/github.com/segmentio/topicctl
     docker:
-      - image: circleci/golang:1.16
+      - image: circleci/golang:1.17
         environment:
           GO111MODULE: "on"
           ECR_ENABLED: True
@@ -207,7 +207,7 @@ jobs:
   publish-ecr:
     working_directory: /go/src/github.com/segmentio/topicctl
     docker:
-      - image: circleci/golang:1.16
+      - image: circleci/golang:1.17
 
     steps:
       - checkout
@@ -233,7 +233,7 @@ jobs:
   publish-dockerhub:
     working_directory: /go/src/github.com/segmentio/topicctl
     docker:
-      - image: circleci/golang:1.16
+      - image: circleci/golang:1.17
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,7 @@ workflows:
               only:
                 - master
                 - v1
+                - yolken-v1-fix-group-lags
       - publish-dockerhub:
           context: docker-publish
           requires:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 ENV SRC github.com/segmentio/topicctl
 ENV CGO_ENABLED=0
 

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -122,7 +122,7 @@ func applyRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigChan

--- a/cmd/topicctl/subcmd/tail.go
+++ b/cmd/topicctl/subcmd/tail.go
@@ -67,7 +67,7 @@ func tailRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigChan

--- a/cmd/topicctl/subcmd/tester.go
+++ b/cmd/topicctl/subcmd/tester.go
@@ -72,7 +72,7 @@ func testerRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigChan

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/pkg/term v0.0.0-20200520122047-c3ffed290a03 // indirect
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
-	github.com/segmentio/kafka-go v0.4.21-0.20211001180856-4d75f822c8b8
+	github.com/segmentio/kafka-go v0.4.21-0.20211001205616-c03923d67699
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/pkg/term v0.0.0-20200520122047-c3ffed290a03 // indirect
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
-	github.com/segmentio/kafka-go v0.4.16
+	github.com/segmentio/kafka-go v0.4.21-0.20211001180856-4d75f822c8b8
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCLY7gIfzeQaUJ+kppEO5WQG3cL8iE8tGHU=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/segmentio/kafka-go v0.4.16 h1:9dt78ehM9qzAkekA60D6A96RlqDzC3hnYYa8y5Szd+U=
-github.com/segmentio/kafka-go v0.4.16/go.mod h1:19+Eg7KwrNKy/PFhiIthEPkO8k+ac7/ZYXwYM9Df10w=
+github.com/segmentio/kafka-go v0.4.21-0.20211001180856-4d75f822c8b8 h1:H45Dpqb99IyjZoq/+WCuVz0UWe2JOrajBVmg6QsYyaQ=
+github.com/segmentio/kafka-go v0.4.21-0.20211001180856-4d75f822c8b8/go.mod h1:XzMcoMjSzDGHcIwpWUI7GB43iKZ2fTVmryPSGLf/MPg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCL
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/segmentio/kafka-go v0.4.21-0.20211001180856-4d75f822c8b8 h1:H45Dpqb99IyjZoq/+WCuVz0UWe2JOrajBVmg6QsYyaQ=
 github.com/segmentio/kafka-go v0.4.21-0.20211001180856-4d75f822c8b8/go.mod h1:XzMcoMjSzDGHcIwpWUI7GB43iKZ2fTVmryPSGLf/MPg=
+github.com/segmentio/kafka-go v0.4.21-0.20211001205616-c03923d67699 h1:DM1XDA47wY0myfsik7hUz+pkmI2uhkfKsa6ogOTNLxw=
+github.com/segmentio/kafka-go v0.4.21-0.20211001205616-c03923d67699/go.mod h1:XzMcoMjSzDGHcIwpWUI7GB43iKZ2fTVmryPSGLf/MPg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/cli/repl.go
+++ b/pkg/cli/repl.go
@@ -202,7 +202,7 @@ func (r *Repl) executor(in string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigChan

--- a/pkg/groups/groups.go
+++ b/pkg/groups/groups.go
@@ -9,6 +9,7 @@ import (
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/topicctl/pkg/admin"
 	"github.com/segmentio/topicctl/pkg/messages"
+	log "github.com/sirupsen/logrus"
 )
 
 // GetGroups fetches and returns information about all consumer groups in the cluster.
@@ -48,15 +49,16 @@ func GetGroupDetails(
 	connector *admin.Connector,
 	groupID string,
 ) (*GroupDetails, error) {
-	describeGroupsResponse, err := connector.KafkaClient.DescribeGroups(
-		ctx,
-		&kafka.DescribeGroupsRequest{
-			GroupIDs: []string{groupID},
-		},
-	)
+	req := kafka.DescribeGroupsRequest{
+		GroupIDs: []string{groupID},
+	}
+	log.Debugf("DescribeGroups request: %+v", req)
+
+	describeGroupsResponse, err := connector.KafkaClient.DescribeGroups(ctx, &req)
 	if err != nil {
 		return nil, err
 	}
+	log.Debugf("DescribeGroups response: %+v", describeGroupsResponse)
 
 	if len(describeGroupsResponse.Groups) != 1 {
 		return nil, fmt.Errorf("Unexpected response length from describeGroups")


### PR DESCRIPTION
## Description
This change updates the version of kakfa-go to pick up the `DescribeGroups` fix in https://github.com/segmentio/kafka-go/pull/752. It also updates the go version used in all images to 1.17.

## Testing
Testing completed successfully via creating a consumer reading from a topic:

```
./build/topicctl tester --broker-addr=localhost:9092 --topic=topic-default`
export KAFKA_VERSION=2.13-2.7.1 ; docker run --network host -it wurstmeister/kafka:$KAFKA_VERSION /opt/kafka_$KAFKA_VERSION/bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic topic-default --group yolken-test-group3 --property print.key=true --property print.timestamp=true --consumer-property 'partition.assignment.strategy=org.apache.kafka.clients.consumer.CooperativeStickyAssignor'
```

and then getting lags for it:

```
./build/topicctl --cluster-config=examples/local-cluster/cluster.yaml get lags topic-default yolken-test-group3 --debug
```

and verifying that no errors occurred.
