### PR TITLE
Support expanding cluster and topic yaml config files with the system environment

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -19,6 +20,8 @@ func LoadClusterFile(path string) (ClusterConfig, error) {
 	if err != nil {
 		return ClusterConfig{}, err
 	}
+
+	contents = []byte(os.ExpandEnv(string(contents)))
 
 	absPath, err := filepath.Abs(path)
 	if err != nil {
@@ -47,6 +50,8 @@ func LoadTopicsFile(path string) ([]TopicConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	contents = []byte(os.ExpandEnv(string(contents)))
 
 	trimmedFile := strings.TrimSpace(string(contents))
 	topicStrs := sep.Split(trimmedFile, -1)


### PR DESCRIPTION
There is currently no support for reading environment variables and change the config file accordingly before applying the config. This PR expands the content read from both cluster and topic config files prior to parsing them.