### PR TITLE
Fix missing CertPath in TLSConfig in cluster.go

### DIFF
--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -183,6 +183,7 @@ func (c ClusterConfig) NewAdminClient(
 					TLS: admin.TLSConfig{
 						Enabled:    c.Spec.TLS.Enabled,
 						CACertPath: c.absPath(c.Spec.TLS.CACertPath),
+						CertPath:   c.absPath(c.Spec.TLS.CertPath),
 						KeyPath:    c.absPath(c.Spec.TLS.KeyPath),
 						ServerName: c.Spec.TLS.ServerName,
 						SkipVerify: c.Spec.TLS.SkipVerify,


### PR DESCRIPTION
It looks like `CertPath` has been omitted from the TLS configuration when creating a broker connection.

When using client authentication with `topicctl bootstrap`, this is resulting in the following error:

```
./topicctl --cluster-config=kafka.yml bootstrap
...
ERROR local error: tls: unexpected message
```

With this change, I've verified that client authentication works correctly.