### PR TITLE
allow extending partition count, even if not a multiple of racks

### DIFF
--- a/pkg/apply/extenders/balanced.go
+++ b/pkg/apply/extenders/balanced.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/segmentio/topicctl/pkg/admin"
 	"github.com/segmentio/topicctl/pkg/apply/pickers"
+	log "github.com/sirupsen/logrus"
 )
 
 // BalancedExtender adds extra partition assignments in a "balanced" way. The current
@@ -51,10 +52,7 @@ func (b *BalancedExtender) Extend(
 	extraPartitions int,
 ) ([]admin.PartitionAssignment, error) {
 	if extraPartitions%len(b.racks) != 0 {
-		return nil,
-			fmt.Errorf(
-				"Cannot balance because extra partitions are not a multiple of the number of racks",
-			)
+		log.Warnf("Extra partitions are not a multiple of the number of racks, balancing will not be ideal")
 	}
 
 	if b.inRack {


### PR DESCRIPTION
Prior to this change, topics with partition counts that are not a multiple of the rack count would be unable to be extended, erroring out with this kind of message (in this case trying to expand from 2 to 21 partitions):

```
 INFO Trying to add 19 additional partitions consistent with 'any' strategy
ERROR Cannot balance because extra partitions are not a multiple of the number of racks
```