### PR TITLE
add shard as a supported field in cluster meta config

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ meta:
   name: my-cluster                      # Name of the cluster
   environment: stage                    # Cluster environment
   region: us-west-2                     # Cloud region of the cluster
+  shard: 1                              # Shard index of this cluster, if it is sharded.
   description: |                        # A free-text description of the cluster (optional)
     Test cluster for topicctl.
 

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -30,6 +30,7 @@ type ClusterMeta struct {
 	Name        string `json:"name"`
 	Region      string `json:"region"`
 	Environment string `json:"environment"`
+	Shard       int    `json:"shard"`
 	Description string `json:"description"`
 }
 


### PR DESCRIPTION
Since we are using a `shard` field in the cluster definition in a dependent repository, add it here to allow `topicctl check` to succeed.