### PR TITLE
Support assuming an intermediate role when using the AWS-MSK-IAM SASL mechanism

### DIFF
--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -61,7 +61,7 @@ func getPreRun(cmd *cobra.Command, args []string) error {
 
 func getRun(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	sess := session.Must(session.NewSession())
+	sess, _ := session.NewSession()
 
 	adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 	if err != nil {

--- a/cmd/topicctl/subcmd/repl.go
+++ b/cmd/topicctl/subcmd/repl.go
@@ -32,7 +32,7 @@ func replPreRun(cmd *cobra.Command, args []string) error {
 
 func replRun(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	sess := session.Must(session.NewSession())
+	sess, _ := session.NewSession()
 
 	adminClient, err := replConfig.shared.getAdminClient(ctx, sess, true)
 	if err != nil {

--- a/pkg/admin/connector.go
+++ b/pkg/admin/connector.go
@@ -48,10 +48,11 @@ type TLSConfig struct {
 
 // SASLConfig stores the SASL-related configuration for a connection.
 type SASLConfig struct {
-	Enabled   bool
-	Mechanism SASLMechanism
-	Username  string
-	Password  string
+	Enabled    bool
+	Mechanism  SASLMechanism
+	Username   string
+	Password   string
+	AssumeRole string
 }
 
 // Connector is a wrapper around the low-level, kafka-go dialer and client.


### PR DESCRIPTION
## Description
This change updates the AWS-MSK-IAM SASL mechanism to optionally support assuming an intermediate role to get the MSK credentials. See https://github.com/segmentio/topicctl/issues/64 for more background and motivation.

The intermediate role ARN can be specified in the cluster config (by setting `assumeRole` in the SASL section) or, for subcommands that don't require a cluster config, on the command-line (by setting the `--sasl-assume-role` flag).

## Testing
TBD