### PR TITLE
use read API instead of write API to verify >2.4.0

### DIFF
--- a/pkg/admin/brokerclient.go
+++ b/pkg/admin/brokerclient.go
@@ -85,9 +85,10 @@ func NewBrokerAdminClient(
 		)
 	}
 
-	// If we have AlterPartitionReassignments support, then we're good for applying (other needed
+	// If we have ListPartitionReassignments support, then we're good for applying (other needed
 	// APIs are older). This should be satisfied by versions >= 2.4.
-	if _, ok := maxVersions["AlterPartitionReassignments"]; ok {
+
+	if _, ok := maxVersions["ListPartitionReassignments"]; ok {
 		supportedFeatures.Applies = true
 	}
 


### PR DESCRIPTION
Allows for compatibility with MSK serverless by using a read API instead of a write API while still verifying cluster version is >2.4.0

fixes #69 