### PR TITLE
[DP-420] add autocontinue flag for rebalance

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,5 +527,4 @@ details on the available versions.
 To run the `get`, `repl`, and `tail` subcommands against the local cluster,
 set `--zk-addr=localhost:2181` and leave the `--zk-prefix` flag unset.
 
-To test out `apply`, you can use the configs in
-`pkg/config/test-configs/local`.
+To test out `apply`, you can use the configs in `examples/local-cluster/`.

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -32,6 +32,7 @@ type applyCmdConfig struct {
 	partitionBatchSizeOverride   int
 	pathPrefix                   string
 	rebalance                    bool
+	autoContinueRebalance        bool
 	retentionDropStepDurationStr string
 	skipConfirm                  bool
 	sleepLoopDuration            time.Duration
@@ -79,6 +80,12 @@ func init() {
 		"rebalance",
 		false,
 		"Explicitly rebalance broker partition assignments",
+	)
+	applyCmd.Flags().BoolVar(
+		&applyConfig.autoContinueRebalance,
+		"auto-continue-rebalance",
+		false,
+		"Continue rebalancing without prompting (WARNING: user discretion advised)",
 	)
 	applyCmd.Flags().StringVar(
 		&applyConfig.retentionDropStepDurationStr,
@@ -218,6 +225,7 @@ func applyTopic(
 			DryRun:                     applyConfig.dryRun,
 			PartitionBatchSizeOverride: applyConfig.partitionBatchSizeOverride,
 			Rebalance:                  applyConfig.rebalance,
+			AutoContinueRebalance:      applyConfig.autoContinueRebalance,
 			RetentionDropStepDuration:  applyConfig.retentionDropStepDuration,
 			SkipConfirm:                applyConfig.skipConfirm,
 			SleepLoopDuration:          applyConfig.sleepLoopDuration,

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -838,7 +838,7 @@ func (t *TopicApplier) updatePlacementRunner(
 	}
 
 	if t.config.AutoContinueRebalance {
-		log.Infof("Autocontinue flag detected, user will not be prompted each round")
+		log.Warnf("Autocontinue flag detected, user will not be prompted each round")
 	}
 
 	ok, _ := Confirm("OK to apply?", t.config.SkipConfirm)
@@ -861,6 +861,7 @@ func (t *TopicApplier) updatePlacementRunner(
 	}
 
 	numRounds := (len(assignmentsToUpdate) + batchSize - 1) / batchSize // Ceil() with integer math
+	roundScoreboard := color.New(color.FgYellow, color.Bold).SprintfFunc()
 	round := 0
 	for i := 0; i < len(assignmentsToUpdate); i += batchSize {
 		end := i + batchSize
@@ -869,7 +870,6 @@ func (t *TopicApplier) updatePlacementRunner(
 			end = len(assignmentsToUpdate)
 		}
 
-		roundScoreboard := color.New(color.FgYellow, color.Bold).SprintfFunc()
 		round += 1
 		log.Infof(
 			"Balancing round %s",

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -862,7 +862,7 @@ func (t *TopicApplier) updatePlacementRunner(
 
 	numRounds := (len(assignmentsToUpdate) + batchSize - 1) / batchSize // Ceil() with integer math
 	roundScoreboard := color.New(color.FgYellow, color.Bold).SprintfFunc()
-	for i, round := 0, 1 ; i < len(assignmentsToUpdate); i, round = i+batchSize, round+1 {
+	for i, round := 0, 1; i < len(assignmentsToUpdate); i, round = i+batchSize, round+1 {
 		end := i + batchSize
 
 		if end > len(assignmentsToUpdate) {

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -107,18 +107,18 @@ func NewTopicApplier(
 
 // Apply runs a single "apply" run on the configured topic. The general flow is:
 //
-// 1. Validate configs
-// 2. Acquire topic lock
-// 3. Check if topic already exists
-// 4. If new:
-//   a. Create the topic
-//   b. Update the placement in accordance with the configured strategy
-// 5. If exists:
-//   a. Check retention and update if needed
-//   b. Check replication factor (can't be updated by topicctl)
-//   c. Check partition count and extend if needed
-//   d. Check partition placement and update/migrate if needed
-//   e. Check partition leaders and update if needed
+//  1. Validate configs
+//  2. Acquire topic lock
+//  3. Check if topic already exists
+//  4. If new:
+//     a. Create the topic
+//     b. Update the placement in accordance with the configured strategy
+//  5. If exists:
+//     a. Check retention and update if needed
+//     b. Check replication factor (can't be updated by topicctl)
+//     c. Check partition count and extend if needed
+//     d. Check partition placement and update/migrate if needed
+//     e. Check partition leaders and update if needed
 func (t *TopicApplier) Apply(ctx context.Context) error {
 	log.Info("Validating configs...")
 	brokerRacks := admin.DistinctRacks(t.brokers)
@@ -673,8 +673,8 @@ func (t *TopicApplier) updatePlacement(
 		}
 		if !result {
 			log.Infof(
-				"Desired strategy is %s, but leaders aren't balanced. It is strongly suggested to do the latter first. " +
-				"This can be done using the \"balanced-leaders\" strategy.",
+				"Desired strategy is %s, but leaders aren't balanced. It is strongly suggested to do the latter first. "+
+					"This can be done using the \"balanced-leaders\" strategy.",
 				desiredPlacement,
 			)
 
@@ -860,7 +860,7 @@ func (t *TopicApplier) updatePlacementRunner(
 		)
 	}
 
-	numRounds := ( len(assignmentsToUpdate) + batchSize - 1 ) / batchSize	// Ceil() with integer math
+	numRounds := (len(assignmentsToUpdate) + batchSize - 1) / batchSize // Ceil() with integer math
 	round := 0
 	for i := 0; i < len(assignmentsToUpdate); i += batchSize {
 		end := i + batchSize
@@ -873,7 +873,7 @@ func (t *TopicApplier) updatePlacementRunner(
 		round += 1
 		log.Infof(
 			"Balancing round %s",
-				roundScoreboard("%d of %d", round, numRounds),
+			roundScoreboard("%d of %d", round, numRounds),
 		)
 
 		err := t.updatePartitionsIteration(

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -862,15 +862,13 @@ func (t *TopicApplier) updatePlacementRunner(
 
 	numRounds := (len(assignmentsToUpdate) + batchSize - 1) / batchSize // Ceil() with integer math
 	roundScoreboard := color.New(color.FgYellow, color.Bold).SprintfFunc()
-	round := 0
-	for i := 0; i < len(assignmentsToUpdate); i += batchSize {
+	for i, round := 0, 1 ; i < len(assignmentsToUpdate); i, round = i+batchSize, round+1 {
 		end := i + batchSize
 
 		if end > len(assignmentsToUpdate) {
 			end = len(assignmentsToUpdate)
 		}
 
-		round += 1
 		log.Infof(
 			"Balancing round %s",
 			roundScoreboard("%d of %d", round, numRounds),

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current topicctl version.
-const Version = "1.5.0"
+const Version = "1.5.1"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current topicctl version.
-const Version = "1.5.1"
+const Version = "1.6.0"


### PR DESCRIPTION
Provides `--auto-continue-rebalance` option that will skip prompting after each rebalance round (this is separate from the prompt to start the rebalance, which can be skipped via `--skip-confirm`).

Also added some output to indicate progress via "Balancing round X of Y" output during rebalance.