### PR TITLE
added message headers to tail output

### DIFF
--- a/cmd/topicctl/subcmd/tail.go
+++ b/cmd/topicctl/subcmd/tail.go
@@ -25,6 +25,7 @@ type tailCmdConfig struct {
 	offset     int64
 	partitions []int
 	raw        bool
+	headers    bool
 
 	shared sharedOptions
 }
@@ -49,6 +50,12 @@ func init() {
 		"raw",
 		false,
 		"Output raw values only",
+	)
+	tailCmd.Flags().BoolVar(
+		&tailConfig.headers,
+		"headers",
+		true,
+		"Output message headers",
 	)
 
 	addSharedFlags(tailCmd, &tailConfig.shared)
@@ -89,6 +96,7 @@ func tailRun(cmd *cobra.Command, args []string) error {
 		-1,
 		"",
 		tailConfig.raw,
+		tailConfig.headers,
 	)
 }
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -518,6 +518,7 @@ func (c *CLIRunner) Tail(
 	maxMessages int,
 	filterRegexp string,
 	raw bool,
+	headers bool,
 ) error {
 	var err error
 	if len(partitions) == 0 {
@@ -538,7 +539,7 @@ func (c *CLIRunner) Tail(
 		10e3,
 		10e6,
 	)
-	stats, err := tailer.LogMessages(ctx, maxMessages, filterRegexp, raw)
+	stats, err := tailer.LogMessages(ctx, maxMessages, filterRegexp, raw, headers)
 	filtered := filterRegexp != ""
 
 	if !raw {

--- a/pkg/cli/repl.go
+++ b/pkg/cli/repl.go
@@ -363,6 +363,7 @@ func (r *Repl) executor(in string) {
 			-1,
 			filterRegexp,
 			command.getBoolValue("raw"),
+			command.getBoolValue("headers"),
 		)
 		if err != nil {
 			log.Errorf("Error: %+v", err)

--- a/pkg/messages/tail.go
+++ b/pkg/messages/tail.go
@@ -162,6 +162,7 @@ func (t *TopicTailer) LogMessages(
 	maxMessages int,
 	filterRegexp string,
 	raw bool,
+	headers bool,
 ) (TailStats, error) {
 	var filterRegexpObj *regexp.Regexp
 	var err error
@@ -256,11 +257,13 @@ func (t *TopicTailer) LogMessages(
 				keyPrinter("Time:     "),
 				valuePrinter(tailMessage.Message.Time.Format(time.RFC3339)),
 			)
-			fmt.Printf(
-				"%s %s\n",
-				keyPrinter("Headers:  "),
-				valuePrinter(formatHeaders(tailMessage.Message.Headers)),
-			)
+			if headers {
+				fmt.Printf(
+					"%s %s\n",
+					keyPrinter("Headers:  "),
+					valuePrinter(formatHeaders(tailMessage.Message.Headers)),
+				)
+			}
 			fmt.Printf(
 				"%s %s\n",
 				keyPrinter("Key:      "),

--- a/pkg/messages/tail.go
+++ b/pkg/messages/tail.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strings"
@@ -257,6 +258,11 @@ func (t *TopicTailer) LogMessages(
 			)
 			fmt.Printf(
 				"%s %s\n",
+				keyPrinter("Headers:  "),
+				valuePrinter(formatHeaders(tailMessage.Message.Headers)),
+			)
+			fmt.Printf(
+				"%s %s\n",
 				keyPrinter("Key:      "),
 				valuePrinter(bytesToStr(tailMessage.Message.Key)),
 			)
@@ -279,4 +285,19 @@ func bytesToStr(input []byte) string {
 		return strings.TrimSpace(string(input))
 	}
 	return fmt.Sprintf("Binary [%+v]", input)
+}
+
+// formatHeaders creates a joined string with all the header keys and their
+// base64-encoded values.
+func formatHeaders(headers []kafka.Header) string {
+	builder := strings.Builder{}
+	for i, h := range headers {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(h.Key)
+		builder.WriteString("=")
+		builder.WriteString(base64.StdEncoding.EncodeToString(h.Value))
+	}
+	return builder.String()
 }


### PR DESCRIPTION
We're making increased use of message headers, so it's important that we be able to see them for debugging purposes. 😄 