### PR TITLE
Handle errors in AlterParitionReassignment client responses

### DIFF
--- a/pkg/admin/brokerclient.go
+++ b/pkg/admin/brokerclient.go
@@ -514,6 +514,9 @@ func (c *BrokerAdminClient) AssignPartitions(
 	if err = resp.Error; err != nil {
 		return err
 	}
+	if err = util.AlterPartitionReassignmentsRequestAssignmentError(resp.PartitionResults); err != nil {
+		return err
+	}
 
 	return err
 }

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -34,3 +34,18 @@ func IncrementalAlterConfigsResponseResourcesError(resources []kafka.Incremental
 	}
 	return nil
 }
+
+func AlterPartitionReassignmentsRequestAssignmentError(results []kafka.AlterPartitionReassignmentsResponsePartitionResult) error {
+	errors := map[int]error{}
+	var hasErrors bool
+	for _, result := range results {
+		if result.Error != nil {
+			hasErrors = true
+			errors[result.PartitionID] = result.Error
+		}
+	}
+	if hasErrors {
+		return fmt.Errorf("%+v", errors)
+	}
+	return nil
+}


### PR DESCRIPTION
This is basically a copy of the problem found in https://github.com/segmentio/topicctl/pull/103.

I suspect there could be other instances of the same pattern in other places.

Example error:
```
Response contains errors: map[0:[39] Invalid Replica Assignment: the replica assignment is invalid: Replica assignment has brokers that are not alive. Replica list:ArrayBuffer(0), live broker list: Set(1, 2, 3) 1:[39] Invalid Replica Assignment: the replica assignment is invalid: Replica assignment has brokers that are not alive. Replica list: ArrayBuffer(1, 2, 0), live broker list: Set(1, 2, 3) 2:[39] Invalid Replica Assignment: the replica assignment is invalid: Replica assignment has brokers that are not alive. Replica list: ArrayBuffer(2, 0, 1), live broker list: Set(1, 2, 3)]
```

TODO:
- [ ] Add tests