### PR TITLE
Adding action rebalance

### DIFF
--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -1,0 +1,275 @@
+package subcmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/segmentio/topicctl/pkg/admin"
+	"github.com/segmentio/topicctl/pkg/apply"
+	"github.com/segmentio/topicctl/pkg/cli"
+	"github.com/segmentio/topicctl/pkg/config"
+	log "github.com/sirupsen/logrus"
+)
+
+var rebalanceCmd = &cobra.Command{
+	Use:     "rebalance",
+	Short:   "rebalance all topic configs for a kafka cluster",
+	Args:    cobra.MinimumNArgs(0),
+	PreRunE: rebalancePreRun,
+	RunE:    rebalanceRun,
+}
+
+type rebalanceCmdConfig struct {
+	brokersToRemove              []int
+	brokerThrottleMBsOverride    int
+	dryRun                       bool
+	partitionBatchSizeOverride   int
+	pathPrefix                   string
+	autoContinueRebalance        bool
+	retentionDropStepDurationStr string
+	skipConfirm                  bool
+	sleepLoopDuration            time.Duration
+
+	shared sharedOptions
+
+	retentionDropStepDuration time.Duration
+}
+
+var rebalanceConfig rebalanceCmdConfig
+
+func init() {
+	rebalanceCmd.Flags().IntSliceVar(
+		&rebalanceConfig.brokersToRemove,
+		"to-remove",
+		[]int{},
+		"Brokers to remove; only applies if rebalance is also set",
+	)
+	rebalanceCmd.Flags().IntVar(
+		&rebalanceConfig.brokerThrottleMBsOverride,
+		"broker-throttle-mb",
+		0,
+		"Broker throttle override (MB/sec)",
+	)
+	rebalanceCmd.Flags().BoolVar(
+		&rebalanceConfig.dryRun,
+		"dry-run",
+		false,
+		"Do a dry-run",
+	)
+	rebalanceCmd.Flags().IntVar(
+		&rebalanceConfig.partitionBatchSizeOverride,
+		"partition-batch-size",
+		0,
+		"Partition batch size override",
+	)
+	rebalanceCmd.Flags().StringVar(
+		&rebalanceConfig.pathPrefix,
+		"path-prefix",
+		os.Getenv("TOPICCTL_APPLY_PATH_PREFIX"),
+		"Prefix for topic config paths",
+	)
+	rebalanceCmd.Flags().BoolVar(
+		&rebalanceConfig.autoContinueRebalance,
+		"auto-continue-rebalance",
+		false,
+		"Continue rebalancing without prompting (WARNING: user discretion advised)",
+	)
+	rebalanceCmd.Flags().StringVar(
+		&rebalanceConfig.retentionDropStepDurationStr,
+		"retention-drop-step-duration",
+		"",
+		"Amount of time to use for retention drop steps",
+	)
+	rebalanceCmd.Flags().BoolVar(
+		&rebalanceConfig.skipConfirm,
+		"skip-confirm",
+		false,
+		"Skip confirmation prompts during apply process",
+	)
+	rebalanceCmd.Flags().DurationVar(
+		&rebalanceConfig.sleepLoopDuration,
+		"sleep-loop-duration",
+		10*time.Second,
+		"Amount of time to wait between partition checks",
+	)
+
+	addSharedConfigOnlyFlags(rebalanceCmd, &rebalanceConfig.shared)
+	RootCmd.AddCommand(rebalanceCmd)
+}
+
+func rebalancePreRun(cmd *cobra.Command, args []string) error {
+	if rebalanceConfig.retentionDropStepDurationStr != "" {
+		var err error
+		rebalanceConfig.retentionDropStepDuration, err = time.ParseDuration(
+			rebalanceConfig.retentionDropStepDurationStr,
+		)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	// topicctl config layout for a kafka cluster (refer folder: topicctl/examples)
+	//   cluster/
+	//   cluster/cluster.yaml
+	//   cluster/topics/
+	//   cluster/topics/topic_1
+	//   cluster/topics/topic_2
+	//
+	// there can be a situation where topics folder is not in cluster dir
+	// hence we specify both --cluster-config and --path-prefix for action:rebalance
+	// However, we check the path-prefix topic configs with cluster yaml for consistency before applying
+	if rebalanceConfig.shared.clusterConfig == "" || rebalanceConfig.pathPrefix == "" {
+		return fmt.Errorf("Must set args --cluster-config & --path-prefix (or) env variables TOPICCTL_CLUSTER_CONFIG & TOPICCTL_APPLY_PATH_PREFIX")
+	}
+
+	return nil
+}
+
+func rebalanceRun(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		cancel()
+	}()
+
+	// Keep a cache of the admin clients with the cluster config path as the key
+	adminClients := map[string]admin.Client{}
+	defer func() {
+		for _, adminClient := range adminClients {
+			adminClient.Close()
+		}
+	}()
+
+	clusterConfigPath := rebalanceConfig.shared.clusterConfig
+	topicConfigDir := rebalanceConfig.pathPrefix
+	clusterConfig, err := config.LoadClusterFile(clusterConfigPath, applyConfig.shared.expandEnv)
+	if err != nil {
+		return err
+	}
+	log.Debugf("clusterConfig: %+v", clusterConfig)
+
+	adminClient, ok := adminClients[clusterConfigPath]
+	if !ok {
+		adminClient, err = clusterConfig.NewAdminClient(
+			ctx,
+			nil,
+			applyConfig.dryRun,
+			applyConfig.shared.saslUsername,
+			applyConfig.shared.saslPassword,
+		)
+		if err != nil {
+			return err
+		}
+		adminClients[clusterConfigPath] = adminClient
+	}
+
+	// get all topic configs from path-prefix i.e topics folder
+	// this folder should only have topic configs
+	// recursive search is not performed in the path-prefix
+	log.Infof("Getting all topic configs from path prefix (from root) %v", topicConfigDir)
+	matches, err := filepath.Glob(topicConfigDir + "/**")
+	if err != nil {
+		return err
+	}
+
+	// iterate through each topic config and initiate rebalance
+	topicConfigs := []config.TopicConfig{}
+	for _, match := range matches {
+		topicConfigs, err = config.LoadTopicsFile(match)
+		if err != nil {
+			return err
+		}
+		for _, topicConfig := range topicConfigs {
+			log.Debugf("topicConfig from file: %+v", topicConfig)
+			log.Infof(
+				"Rebalancing topic %s in config %s with cluster config %s",
+				topicConfig.Meta.Name,
+				match,
+				clusterConfigPath,
+			)
+			if err := rebalanceApplyTopic(ctx, topicConfig, clusterConfig, adminClient); err != nil {
+				log.Errorf("Ignoring topic %v for rebalance. Got error: %+v", topicConfig.Meta.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Perform rebalance on a topic. returns error if unsuccessful
+// topic will not be rebalanced if
+//   - topic config is inconsistent with cluster config (name, region, environment etc...)
+//   - partitions of a topic in kafka cluster does not match with topic partition setting in topic config
+//   - retention.ms of a topic in kafka cluster does not match with topic retentionMinutes setting in topic config
+//
+// to ensure there are no disruptions to kafka cluster
+// topics that are not present in kafka cluster will be applied
+func rebalanceApplyTopic(
+	ctx context.Context,
+	topicConfig config.TopicConfig,
+	clusterConfig config.ClusterConfig,
+	adminClient admin.Client,
+) error {
+	// validate topic config is valid for the cluster config
+	if err := config.CheckConsistency(topicConfig, clusterConfig); err != nil {
+		return err
+	}
+
+	topicExistsKafka := true
+	topicConfig.SetDefaults()
+	topicInfo, err := adminClient.GetTopic(ctx, topicConfig.Meta.Name, true)
+	if err != nil {
+		if err == admin.ErrTopicDoesNotExist {
+			topicExistsKafka = false
+			log.Infof("Topic: %s does not exist in Kafka cluster", topicConfig.Meta.Name)
+		} else {
+			return err
+		}
+	}
+
+	if topicExistsKafka {
+		log.Infof("Check topic partitions...")
+		log.Debugf("topicInfo from kafka: %+v", topicInfo)
+		if len(topicInfo.Partitions) != topicConfig.Spec.Partitions {
+			return fmt.Errorf("Topic partitions in kafka does not match with topic config file")
+		}
+
+		log.Infof("Check topic retention.ms...")
+		if topicInfo.Config["retention.ms"] != strconv.Itoa(topicConfig.Spec.RetentionMinutes*60000) {
+			return fmt.Errorf("Topic retention in kafka does not match with topic config file")
+		}
+	}
+
+	applierConfig := apply.TopicApplierConfig{
+		BrokerThrottleMBsOverride:  rebalanceConfig.brokerThrottleMBsOverride,
+		BrokersToRemove:            rebalanceConfig.brokersToRemove,
+		ClusterConfig:              clusterConfig,
+		DryRun:                     rebalanceConfig.dryRun,
+		PartitionBatchSizeOverride: rebalanceConfig.partitionBatchSizeOverride,
+		Rebalance:                  true, // to enforce action: rebalance
+		AutoContinueRebalance:      rebalanceConfig.autoContinueRebalance,
+		RetentionDropStepDuration:  rebalanceConfig.retentionDropStepDuration,
+		SkipConfirm:                rebalanceConfig.skipConfirm,
+		SleepLoopDuration:          rebalanceConfig.sleepLoopDuration,
+		TopicConfig:                topicConfig,
+	}
+
+	cliRunner := cli.NewCLIRunner(adminClient, log.Infof, false)
+	if err := cliRunner.ApplyTopic(ctx, applierConfig); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -203,11 +203,11 @@ func rebalanceRun(cmd *cobra.Command, args []string) error {
 
 			stop := make(chan bool)
 			rebalanceMetricConfig := util.RebalanceMetricConfig{
-				topicConfig.Meta.Name,
-				clusterConfig.Meta.Name,
-				clusterConfig.Meta.Environment,
-				rebalanceConfig.brokersToRemove,
-				"inprogress",
+				TopicName: topicConfig.Meta.Name,
+				ClusterName: clusterConfig.Meta.Name,
+				ClusterEnvironment: clusterConfig.Meta.Environment,
+				ToRemove: rebalanceConfig.brokersToRemove,
+				RebalanceStatus: "inprogress",
 			}
 			metricStr, err := util.MetricConfigStr(rebalanceMetricConfig)
 			if err != nil {

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -245,9 +245,9 @@ func rebalanceApplyTopic(
 		} 
 		return err
 	}
-
-	log.Infof("Check topic partitions...")
 	log.Debugf("topicInfo from kafka: %+v", topicInfo)
+	
+	log.Infof("Check topic partitions...")
 	if len(topicInfo.Partitions) != topicConfig.Spec.Partitions {
 		return fmt.Errorf("Topic partitions in kafka does not match with topic config file")
 	}

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -226,7 +226,7 @@ func rebalanceTopicCheck(
 	clusterConfig config.ClusterConfig,
 	topicInfo admin.TopicInfo,
 ) error {
-	// validate topic config is valid for the cluster config
+	// topic config should be same as the cluster config
 	if err := config.CheckConsistency(topicConfig, clusterConfig); err != nil {
 		return err
 	}

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -202,14 +202,14 @@ func rebalanceRun(cmd *cobra.Command, args []string) error {
 			)
 
 			stop := make(chan bool)
-			metricConfig := util.RebalanceMetricConfig{
+			rebalanceMetricConfig := util.RebalanceMetricConfig{
 				topicConfig.Meta.Name,
 				clusterConfig.Meta.Name,
 				clusterConfig.Meta.Environment,
 				rebalanceConfig.brokersToRemove,
 				"inprogress",
 			}
-			metricStr, err := util.MetricConfigStr(metricConfig)
+			metricStr, err := util.MetricConfigStr(rebalanceMetricConfig)
 			if err != nil {
 				log.Errorf("Error: %+v", err)
 			}
@@ -217,13 +217,13 @@ func rebalanceRun(cmd *cobra.Command, args []string) error {
 			topicErrorDict[topicConfig.Meta.Name] = nil
 			if err := rebalanceApplyTopic(ctx, topicConfig, clusterConfig, adminClient); err != nil {
 				topicErrorDict[topicConfig.Meta.Name] = err
-				metricConfig.RebalanceStatus = "error"
+				rebalanceMetricConfig.RebalanceStatus = "error"
 				log.Errorf("Ignoring topic %v for rebalance. Got error: %+v", topicConfig.Meta.Name, err)
 			} else {
-				metricConfig.RebalanceStatus = "success"
+				rebalanceMetricConfig.RebalanceStatus = "success"
 			}
 			stop <- true
-			metricStr, err = util.MetricConfigStr(metricConfig)
+			metricStr, err = util.MetricConfigStr(rebalanceMetricConfig)
 			if err != nil {
 				log.Errorf("Error: %+v", err)
 			}

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -183,9 +183,9 @@ func rebalanceRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	topicErrorDict := make(map[string]error)
 	// iterate through each topic config and initiate rebalance
 	topicConfigs := []config.TopicConfig{}
+	topicErrorDict := make(map[string]error)
 	for _, match := range matches {
 		topicConfigs, err = config.LoadTopicsFile(match)
 		if err != nil {

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -879,12 +879,12 @@ func (t *TopicApplier) updatePlacementRunner(
 
 		// print metrics during each iteration
 		applyMetricConfig := util.ApplyMetricConfig{
-			round,
-			numRounds,
-			t.topicName,
-			t.clusterConfig.Meta.Name,
-			t.clusterConfig.Meta.Environment,
-			t.config.BrokersToRemove,
+			CurrRound: round,
+			TotalRounds: numRounds,
+			TopicName: t.topicName,
+			ClusterName: t.clusterConfig.Meta.Name,
+			ClusterEnvironment: t.clusterConfig.Meta.Environment,
+			ToRemove: t.config.BrokersToRemove,
 		}
 		metricStr, err := util.MetricConfigStr(applyMetricConfig)
 		if err != nil {

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -878,7 +878,7 @@ func (t *TopicApplier) updatePlacementRunner(
 		)
 
 		// print metrics during each iteration
-		metricConfig := util.ApplyMetricConfig{
+		applyMetricConfig := util.ApplyMetricConfig{
 			round,
 			numRounds,
 			t.topicName,
@@ -886,7 +886,7 @@ func (t *TopicApplier) updatePlacementRunner(
 			t.clusterConfig.Meta.Environment,
 			t.config.BrokersToRemove,
 		}
-		metricStr, err := util.MetricConfigStr(metricConfig)
+		metricStr, err := util.MetricConfigStr(applyMetricConfig)
 		if err != nil {
 			log.Errorf("Error: %+v", err)
 		}

--- a/pkg/util/metric.go
+++ b/pkg/util/metric.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"time"
+	"encoding/json"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	metricDuration = 5
+)
+
+// Rebalance Metric Config
+type RebalanceMetricConfig struct {
+	TopicName          string  `json:"topicName"`
+	ClusterName        string  `json:"clusterName"`
+	ClusterEnvironment string  `json:"clusterEnvironment"`
+	ToRemove           []int   `json:"toRemove"`
+	RebalanceStatus    string  `json:"rebalanceStatus"`
+}
+
+// Apply Metric Config
+type ApplyMetricConfig struct {
+	CurrRound          int     `json:"round"`
+	TotalRounds        int     `json:"totalRounds"`
+	TopicName          string  `json:"topicName"`
+	ClusterName        string  `json:"clusterName"`
+	ClusterEnvironment string  `json:"clusterEnvironment"`
+	ToRemove           []int   `json:"toRemove"`
+}
+
+// Print Metrics for each iteration
+// This can be configured but that will need lots of TopicConfig struct changes
+// For now, emitting metrics every 5seconds. refer metricDuration
+// Output log can be grepped and parsed for monitoring sake
+func PrintMetrics(metricStr string, stop chan bool){
+	// ticker waits for metricDuration. Hence we print first and then ticker to do its job
+	log.Infof("Metric: %s", metricStr)
+
+	ticker := time.NewTicker(metricDuration * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			log.Infof("Metric: %s", metricStr)
+		case <-stop:
+			return
+		}
+	}
+}
+
+func MetricConfigStr(metricConfig interface{}) (string, error) {
+	jsonBytes, err := json.Marshal(metricConfig)
+	metricStr := "{}"
+	if err != nil {
+		return metricStr, err
+	} else {
+		metricStr = string(jsonBytes)
+	}
+	return metricStr, nil
+}


### PR DESCRIPTION
Introduction: 
To rebalance a topic in topicctl, We currently use `topicctl apply $topic --rebalance` / `topicctl apply $topic --rebalance --to-remove` . In a production scale Kafka cluster, there is a need to rebalance all topics for a cluster.

Goal:
- Add new action - rebalance to topicctl. i.e `topicctl rebalance`
- Print rebalance status / Metric information (stdout) during rebalance. Refer log `[timestamp] INFO Metric: {}`. Please refer below screenshots for output. 
- Rebalance status / metrics information is two fold. overall topic rebalance status and topic rebalance status for each iteration 

Considerations for action rebalance:
1. expects --cluster-config (i.e cluster.yaml) and --path-prefix (topics folder)
2. Uses underlying topicctl pkg/apply to rebalance a topic. 


NOTE: 
A topic is not considered for rebalance if
- topic config is inconsistent with cluster config (name, region, environment etc...)
- partitions of a topic in kafka cluster does not match with topic partition setting in topic config
- retention.ms of a topic in kafka cluster does not match with topic retentionMinutes setting in topic config
- topic does not exist in kafka cluster

Test Ouput:

Tested on local  kafka cluster (3 brokers, 1 in each rack) with 3 topics 
test-1 -> exists in kafka. But settings mismatch with test-1 topic yaml config
test-2 -> exists in kafka. settings match (replication 2)
test-3 -> does not exist in kafka

---------

`# go run cmd/topicctl/main.go -h`
<img width="814" alt="Screenshot 2023-05-18 at 08 14 59" src="https://github.com/segmentio/topicctl/assets/105226401/c7186535-d539-417c-a083-9bb417279022">

`# go run cmd/topicctl/main.go rebalance -h`
<img width="1081" alt="Screenshot 2023-05-18 at 08 07 15" src="https://github.com/segmentio/topicctl/assets/105226401/c67a61e2-4869-4e60-89ea-a5d66f14138a">

<img width="1329" alt="Screenshot 2023-05-18 at 08 12 52" src="https://github.com/segmentio/topicctl/assets/105226401/9b9f9a98-b650-4c67-b549-099663decb4d">

---------

`# go run cmd/topicctl/main.go rebalance --cluster-config $CLUSTER/cluster.yaml --path-prefix $CLUSTER/topics/ --auto-continue-rebalance --skip-confirm --partition-batch-size 5 --broker-throttle-mb 640`
<img width="1723" alt="Screenshot 2023-05-18 at 22 43 12" src="https://github.com/segmentio/topicctl/assets/105226401/1b270091-0016-40d4-bf1e-4edce7a95b9e">

---------

`# go run cmd/topicctl/main.go rebalance --cluster-config $CLUSTER/cluster.yaml --path-prefix $CLUSTER/topics/ --auto-continue-rebalance --skip-confirm --partition-batch-size 5 --broker-throttle-mb 640 --to-remove 3`

<img width="1726" alt="Screenshot 2023-05-18 at 22 45 47" src="https://github.com/segmentio/topicctl/assets/105226401/082db00c-9dfc-4107-95ae-e01126a2db3f">

<img width="1730" alt="Screenshot 2023-05-18 at 22 46 13" src="https://github.com/segmentio/topicctl/assets/105226401/4a27aa3e-cb50-46b9-a17c-15ff36a65931">

<img width="1728" alt="Screenshot 2023-05-18 at 22 46 34" src="https://github.com/segmentio/topicctl/assets/105226401/60417c71-3c8f-4f2a-91e7-03de4cf11ae7">

<img width="1727" alt="Screenshot 2023-05-18 at 22 47 38" src="https://github.com/segmentio/topicctl/assets/105226401/6ffa76b8-a02d-4427-8865-5731fe6e343d">

<img width="1722" alt="Screenshot 2023-05-18 at 22 48 21" src="https://github.com/segmentio/topicctl/assets/105226401/4ad62141-278c-4aa9-a538-e9f8082cefac">

<img width="1723" alt="Screenshot 2023-05-18 at 22 48 48" src="https://github.com/segmentio/topicctl/assets/105226401/8d5c534b-e79f-47b6-9240-45eb8694ef95">

<img width="1723" alt="Screenshot 2023-05-18 at 22 49 20" src="https://github.com/segmentio/topicctl/assets/105226401/c9765a75-bd4a-4c20-861c-36d330ee5081">
