### PR TITLE
Improve `cross-rack` replication checks (#138)

### DIFF
--- a/pkg/config/topic.go
+++ b/pkg/config/topic.go
@@ -274,7 +274,7 @@ func (t TopicConfig) Validate(numRacks int) error {
 			)
 		}
 	case PlacementStrategyCrossRack:
-		if t.Spec.ReplicationFactor > numRacks {
+		if numRacks > 0 && t.Spec.ReplicationFactor > numRacks {
 			err = multierror.Append(
 				err,
 				fmt.Errorf(

--- a/scripts/set_up_net_alias.sh
+++ b/scripts/set_up_net_alias.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ADDR=169.254.123.123
 echo "Aliasing $ADDR to localhost..."


### PR DESCRIPTION
If `--validate-only` is set the number of racks needed is ignored.

If there are broker connections, use the actual number of racks in the
cluster.

Use `/bin/bash` for `set_up_net_alias.sh`.
`[[ … ]]` is a bashism and doesn’t work with all `sh`.