### PR TITLE
Dp 1495 reset offsets command for multiple partitions at once

### DIFF
--- a/cmd/topicctl/subcmd/reset.go
+++ b/cmd/topicctl/subcmd/reset.go
@@ -119,10 +119,10 @@ func resetOffsetsRun(cmd *cobra.Command, args []string) error {
 		for partition, offset := range resetOffsetsConfig.partitionOffsetMap {
 			var partitionID int
 			if partitionID, err = strconv.Atoi(partition); err != nil {
-				return fmt.Errorf("partition value %s must be a number", partition)
+				return fmt.Errorf("Partition value %s must be a number", partition)
 			}
 			if _, ok := partitionIDsMap[partitionID]; !ok {
-				return fmt.Errorf("partition %d not found in topic %s", partitionID, topic)
+				return fmt.Errorf("Partition %d not found in topic %s", partitionID, topic)
 			}
 
 			partitionOffsets[partitionID] = offset
@@ -132,7 +132,7 @@ func resetOffsetsRun(cmd *cobra.Command, args []string) error {
 	} else if len(resetOffsetsConfig.partitions) > 0 {
 		for _, partition := range resetOffsetsConfig.partitions {
 			if _, ok := partitionIDsMap[partition]; !ok {
-				return fmt.Errorf("partition %d not found in topic %s", partition, topic)
+				return fmt.Errorf("Partition %d not found in topic %s", partition, topic)
 			}
 			if resetOffsetsConfig.toEarliest || resetOffsetsConfig.toLatest {
 				partitionOffsets[partition], err = groups.GetEarliestOrLatestOffset(ctx, adminClient.GetConnector(), topic, resetOffsetsStrategy, partition)
@@ -169,7 +169,7 @@ func resetOffsetsRun(cmd *cobra.Command, args []string) error {
 
 	ok, _ := apply.Confirm("OK to continue?", false)
 	if !ok {
-		return errors.New("stopping because of user response")
+		return errors.New("Stopping because of user response")
 	}
 
 	cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)

--- a/cmd/topicctl/subcmd/reset.go
+++ b/cmd/topicctl/subcmd/reset.go
@@ -38,19 +38,19 @@ func init() {
 		&resetOffsetsConfig.offset,
 		"offset",
 		-2,
-		"Offset",
+		"Desired offset for the target partitions",
 	)
 	resetOffsetsCmd.Flags().IntSliceVar(
 		&resetOffsetsConfig.partitions,
 		"partitions",
 		[]int{},
-		"Partition (defaults to all)",
+		"List of partitions to reset e.g. 1,2,3,.. (defaults to all)",
 	)
 	resetOffsetsCmd.Flags().StringToInt64Var(
 		&resetOffsetsConfig.partitionOffsetMap,
 		"partition-offset-map",
 		map[string]int64{},
-		"Map of partition IDs to their corresponding desired offsets",
+		"Map of partition IDs to their corresponding desired offsets e.g. 1=5,2=10,3=12,...",
 	)
 	resetOffsetsCmd.Flags().BoolVar(
 		&resetOffsetsConfig.toEarliest,


### PR DESCRIPTION
tested locally with the following setup:


p1-------------->[topic-1]
                                    [cg1]__________> c1
                                    [cg2]__________>c2
                                                       \____>c3

p2-------------->[topic-2]
                                    [cg3]__________>c4
                                                       \____>c5


this change adds the option --partition-offset-map to the reset-offsets command which allows the use to set multiple offsets for a list of partitions simultaneously in the following manner:

--partition-offset-map <part_id_1>=<offset_1>,<part_id_2>=<offset_2>,....

 