### PR TITLE
[DP-1762] - topicctl get actions for under replicated and offline partitions

### DIFF
--- a/pkg/admin/format.go
+++ b/pkg/admin/format.go
@@ -884,3 +884,117 @@ func maxMapValues(inputMap map[int]int) int {
 
 	return maxValue
 }
+
+// FormatURPs creates a pretty table that lists the details of the
+// under replicated topic partitions
+func FormatURPs(allTopicURPs []TopicURPsInfo) string {
+	buf := &bytes.Buffer{}
+
+	headers := []string{
+		"Name",
+		"Partition",
+		"Leader",
+		"ISR",
+		"Replicas",
+	}
+
+	table := tablewriter.NewWriter(buf)
+	table.SetHeader(headers)
+	table.SetAutoWrapText(false)
+	table.SetColumnAlignment(
+		[]int{
+			tablewriter.ALIGN_LEFT,
+			tablewriter.ALIGN_LEFT,
+			tablewriter.ALIGN_LEFT,
+			tablewriter.ALIGN_LEFT,
+			tablewriter.ALIGN_LEFT,
+		},
+	)
+	table.SetBorders(
+		tablewriter.Border{
+			Left:   false,
+			Top:    true,
+			Right:  false,
+			Bottom: true,
+		},
+	)
+
+	for _, topicURPs := range allTopicURPs {
+		for _, topicPartition := range topicURPs.Partitions {
+			row := []string{
+				topicURPs.Name,
+				fmt.Sprintf("%d", topicPartition.ID),
+				fmt.Sprintf("%d", topicPartition.Leader),
+				fmt.Sprintf("%+v", topicPartition.ISR),
+				fmt.Sprintf("%+v", topicPartition.Replicas),
+			}
+
+			table.Append(row)
+		}
+	}
+
+	table.Render()
+	return string(bytes.TrimRight(buf.Bytes(), "\n"))
+}
+
+// FormatOPs creates a pretty table that lists the details of the
+// offline topic partitions
+func FormatOPs(allTopicOPs []TopicOPsInfo) string {
+	buf := &bytes.Buffer{}
+
+	headers := []string{
+		"Name",
+		"Partition",
+		"Leader",
+		"ISR",
+		"Replicas",
+	}
+
+	table := tablewriter.NewWriter(buf)
+	table.SetHeader(headers)
+	table.SetAutoWrapText(false)
+	table.SetColumnAlignment(
+		[]int{
+			tablewriter.ALIGN_LEFT,
+			tablewriter.ALIGN_LEFT,
+			tablewriter.ALIGN_LEFT,
+			tablewriter.ALIGN_LEFT,
+			tablewriter.ALIGN_LEFT,
+		},
+	)
+	table.SetBorders(
+		tablewriter.Border{
+			Left:   false,
+			Top:    true,
+			Right:  false,
+			Bottom: true,
+		},
+	)
+
+	for _, topicOPs := range allTopicOPs {
+		for _, topicPartition := range topicOPs.Partitions {
+			topicPartitionIsrs := []int{}
+			for _, topicPartitionIsr := range topicPartition.Isr {
+				topicPartitionIsrs = append(topicPartitionIsrs, topicPartitionIsr.ID)
+			}
+
+			topicPartitionReplicas := []int{}
+			for _, topicPartitionReplica := range topicPartition.Replicas {
+				topicPartitionReplicas = append(topicPartitionReplicas, topicPartitionReplica.ID)
+			}
+
+			row := []string{
+				topicOPs.Name,
+				fmt.Sprintf("%d", topicPartition.ID),
+				fmt.Sprintf("%d", topicPartition.Leader.ID),
+				fmt.Sprintf("%+v", topicPartitionIsrs),
+				fmt.Sprintf("%+v", topicPartitionReplicas),
+			}
+
+			table.Append(row)
+		}
+	}
+
+	table.Render()
+	return string(bytes.TrimRight(buf.Bytes(), "\n"))
+}

--- a/pkg/admin/types.go
+++ b/pkg/admin/types.go
@@ -138,12 +138,12 @@ type zkChangeNotification struct {
 }
 
 type TopicURPsInfo struct {
-	Name       string          `json:topic`
+	Name       string          `json:"name"`
 	Partitions []PartitionInfo `json:"partitions"`
 }
 
 type TopicOPsInfo struct {
-	Name       string            `json:topic`
+	Name       string            `json:"name"`
 	Partitions []kafka.Partition `json:"partitions"`
 }
 

--- a/pkg/admin/types.go
+++ b/pkg/admin/types.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/topicctl/pkg/util"
 )
 
@@ -134,6 +135,16 @@ type zkElectionTopicPartition struct {
 type zkChangeNotification struct {
 	Version    int    `json:"version"`
 	EntityPath string `json:"entity_path"`
+}
+
+type TopicURPsInfo struct {
+	Name       string          `json:topic`
+	Partitions []PartitionInfo `json:"partitions"`
+}
+
+type TopicOPsInfo struct {
+	Name       string            `json:topic`
+	Partitions []kafka.Partition `json:"partitions"`
 }
 
 // Addr returns the address of the current BrokerInfo.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -534,7 +534,7 @@ func (c *CLIRunner) GetUnderReplicatedPartitions(ctx context.Context, topics []s
 	c.printer("Under Replicated Partitions:\n%s", admin.FormatURPs(allTopicURPs))
 
 	if urpsFound {
-		return fmt.Errorf("Cluster has Under Replicated Partitions")
+		return fmt.Errorf("Topics have Under Replicated Partitions")
 	}
 
 	return nil
@@ -614,7 +614,7 @@ func (c *CLIRunner) GetOfflinePartitions(ctx context.Context, topics []string) e
 	c.printer("Offline Partitions:\n%s", admin.FormatOPs(allTopicOPs))
 
 	if opsFound {
-		return fmt.Errorf("Cluster has Offline Partitions")
+		return fmt.Errorf("Topics have Offline Partitions")
 	}
 
 	return nil


### PR DESCRIPTION
# Description
This PR is to add new actions for `topicctl get`

## Expectations:
- topicctl get under-replicated-partitions (optional --topics flag)
- topicctl get offline-partitions (optional --topics flag)
- Fix the debug `PersistentPreRunE: getPreRun` in topicctl get since topicctl get is overriding the root cmd PersistentPreRunE: preRun

## under replicated partitions
- Kafka cluster is in under replicated state if the number of ISR are less than the Replicas available for the partition
- topicctl already has readily available metadata call with filtered information. We will leverage topicctl admin pkg for under-replicated-partitions

## offline partitions
- topicctl has admin.GetTopics which performs kafka Metadata call, there is a lot of formatting and missing information in admin.GetTopics. Hence we will perform the kafka-go client.Metadata to ensure we capture all the offline partition information.
- We leverage kafka-go metadata for offline-partitions


kafka-go metadata call for offline partitions gives the Leader partition information as below:

kafka "github.com/segmentio/kafka-go"

partition: 
```
{
	Topic: topic_name
	ID: partition_id
	Leader: kafka.Broker (refer below)
	Replicas: [][Broker
	Isr:  [][Broker
	Error: kafka.Error
}
```

partition.Leader Broker response:
```
kafka.Broker{
        Host: ""
	Port: 0
	ID: 0
	Rack: ""
}
```
Unlike sarama which gives the offline leader broker id as -1, kafka-go gives the offline broker id as 0

Hence we will check the below error code: ListenerNotFound  along with broker.Host as "" and broker.Port as 0 for partitions information in the metadata response
- error message: `"there is no listener on the leader broker that matches the listener on which metadata request was processed"`
- kafka.Error reference: https://github.com/segmentio/kafka-go/blob/main/error.go#L87

Expectation: if kafka.Error is ListenerNotFound  and there is no broker or port found for leader partition, there by confirming that the partition is offline. We will display the ISR.ID and Repicas.ID with information from the kafka-go metadata call (i.e: each offline partition - Isr.ID and Replicas.ID as 0)