### PR TITLE
fix issues from get subcmd refactor

### DIFF
--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -63,24 +63,6 @@ func getPreRun(cmd *cobra.Command, args []string) error {
 	return getConfig.shared.validate()
 }
 
-func getCliRunnerAndCtx() (
-	context.Context,
-	*cli.CLIRunner,
-	error,
-) {
-	ctx := context.Background()
-	sess := session.Must(session.NewSession())
-
-	adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer adminClient.Close()
-
-	cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
-	return ctx, cliRunner, nil
-}
-
 func balanceCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "balance [optional topic]",
@@ -93,10 +75,16 @@ func balanceCmd() *cobra.Command {
 		),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 
 			var topicName string
 			if len(args) == 1 {
@@ -114,10 +102,16 @@ func brokersCmd() *cobra.Command {
 		Short: "Displays descriptions of each broker in the cluster.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetBrokers(ctx, getConfig.full)
 		},
 	}
@@ -129,11 +123,16 @@ func configCmd() *cobra.Command {
 		Short: "Displays configuration for the provider broker or topic.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
 
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetConfig(ctx, args[0])
 		},
 	}
@@ -145,10 +144,16 @@ func groupsCmd() *cobra.Command {
 		Short: "Displays consumer group informatin for the cluster.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetGroups(ctx)
 		},
 	}
@@ -160,10 +165,16 @@ func lagsCmd() *cobra.Command {
 		Short: "Displays consumer group lag for the specified topic and consumer group.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetMemberLags(
 				ctx,
 				args[0],
@@ -181,10 +192,16 @@ func membersCmd() *cobra.Command {
 		Short: "Details of each member in the specified consumer group.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetGroupMembers(ctx, args[0], getConfig.full)
 		},
 	}
@@ -196,10 +213,16 @@ func partitionsCmd() *cobra.Command {
 		Short: "Displays partition information for the specified topic.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetPartitions(ctx, args[0])
 		},
 	}
@@ -211,10 +234,16 @@ func offsetsCmd() *cobra.Command {
 		Short: "Displays offset information for the specified topic along with start and end times.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetOffsets(ctx, args[0])
 		},
 	}
@@ -226,10 +255,16 @@ func topicsCmd() *cobra.Command {
 		Short: "Displays information for all topics in the cluster.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cliRunner, err := getCliRunnerAndCtx()
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
 			if err != nil {
 				return err
 			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetTopics(ctx, getConfig.full)
 		},
 	}

--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -60,6 +60,9 @@ func init() {
 }
 
 func getPreRun(cmd *cobra.Command, args []string) error {
+	if err := RootCmd.PersistentPreRunE(cmd, args); err != nil {
+		return err
+	}
 	return getConfig.shared.validate()
 }
 


### PR DESCRIPTION
https://github.com/segmentio/topicctl/pull/148 introduced two new (known) bugs that are fixed in this PR:
1. The debug command broke for the get subcommand. This is due to PersistentPreRun only traversing one level of subcommands. This is a [known issue with cobra](https://github.com/spf13/cobra/issues/252)
2. Zookeeper get commands broke. This [commit](https://github.com/segmentio/topicctl/pull/148/commits/07667ddf64bfbe9383cb2ae9f2f6b548f169f157) closes the adminclient before the function returns with the defer command, which is not what we want to do. We must keep the adminclient open until the end of the command so this PR reverts that commit which added the buggy `getCliRunnerAndCtx` function

Verification:
1. Debug flag fix

Before:
```bash
go run cmd/topicctl/main.go get topics --cluster-config examples/local-cluster/cluster.yaml --debug
[2023-09-18 08:55:33]  INFO Topics:
-------+------------+-------------+-----------+------------
  NAME | PARTITIONS | REPLICATION | RETENTION |   RACKS
       |            |             |   MINS    | (MIN,MAX)
-------+------------+-------------+-----------+------------
-------+------------+-------------+-----------+------------
```
After:
```bash
$ go run cmd/topicctl/main.go get topics --cluster-config examples/local-cluster/cluster.yaml --debug
[2023-09-18 08:55:29] DEBUG No ZK addresses provided, using broker admin client
[2023-09-18 08:55:29] DEBUG Connecting to cluster on address localhost:9092 with TLS enabled=false, SASL enabled=false
[2023-09-18 08:55:29] DEBUG Getting supported API versions
...
```
2. Zk Fix

Before:
```bash
$ go run cmd/topicctl/main.go get brokers --zk-addr localhost:2181
panic: send on closed channel

goroutine 1 [running]:
github.com/segmentio/topicctl/pkg/zk.(*PooledClient).Children(0xc00017c570, {0x1ba3770, 0xc000122000}, {0xc00062e0c0, 0xc})
        /Users/pdannemann/src/topicctl/pkg/zk/client.go:182 +0x12e
github.com/segmentio/topicctl/pkg/admin.(*ZKAdminClient).GetBrokerIDs(0xc000212280, {0x1ba3770, 0xc000122000})
        /Users/pdannemann/src/topicctl/pkg/admin/zkclient.go:274 +0xb6
github.com/segmentio/topicctl/pkg/admin.(*ZKAdminClient).GetBrokers(0xc000212280, {0x1ba3770, 0xc000122000}, {0x0?, 0x0?, 0xc0004dc480?})
        /Users/pdannemann/src/topicctl/pkg/admin/zkclient.go:174 +0x53
github.com/segmentio/topicctl/pkg/cli.(*CLIRunner).GetBrokers(0xc0004dc480, {0x1ba3770?, 0xc000122000?}, 0x0?)
        /Users/pdannemann/src/topicctl/pkg/cli/cli.go:69 +0x85
github.com/segmentio/topicctl/cmd/topicctl/subcmd.brokersCmd.func1(0xc0004fe000?, {0xc0004dc200?, 0x2?, 0x2?})
        /Users/pdannemann/src/topicctl/cmd/topicctl/subcmd/get.go:121 +0x49
github.com/spf13/cobra.(*Command).execute(0xc0004fe000, {0xc0004dc1e0, 0x2, 0x2})
        /Users/pdannemann/dev/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:872 +0x694
github.com/spf13/cobra.(*Command).ExecuteC(0x1feae60)
        /Users/pdannemann/dev/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/pdannemann/dev/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
github.com/segmentio/topicctl/cmd/topicctl/subcmd.Execute({0x1838289?, 0xc0000021a0?})
        /Users/pdannemann/src/topicctl/cmd/topicctl/subcmd/root.go:49 +0xb1
main.main()
        /Users/pdannemann/src/topicctl/cmd/topicctl/main.go:13 +0x27
```
After:
```bash
$ go run cmd/topicctl/main.go get brokers --zk-addr localhost:2181
[2023-09-18 08:56:22]  INFO Brokers:
-----+-----------+------+------+-----------------------
  ID |   HOST    | PORT | RACK |      TIMESTAMP
-----+-----------+------+------+-----------------------
  1  | localhost | 9092 |      | 2023-09-16T17:06:33Z
-----+-----------+------+------+-----------------------
[2023-09-18 08:56:22]  INFO Brokers per rack:
-------+--------------
  RACK | NUM BROKERS
-------+--------------
       | 1
-------+--------------
```
