### PR TITLE
[DP-1767] - topicctl get action partitions-status

### DIFF
--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -39,7 +39,7 @@ type partitionsStatusCmdConfig struct {
 }
 
 var partitionsStatusConfig partitionsStatusCmdConfig
-var partitionsStatusHelpText = "Allowed values: under-replicated, offline, preferred-leder, not-preferred-leader"
+var partitionsStatusHelpText = "Allowed values: under-replicated, offline, preferred-leader, not-preferred-leader"
 
 func init() {
 	getCmd.PersistentFlags().BoolVar(

--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -319,7 +319,7 @@ func partitionsStatusCmd() *cobra.Command {
 		"topics",
 		"t",
 		[]string{},
-		"fetch specific topics partition status",
+		"fetch specific topics partition status (comma delimitted)",
 	)
 
 	partitionsStatusCommand.Flags().StringVarP(

--- a/pkg/admin/format.go
+++ b/pkg/admin/format.go
@@ -923,7 +923,7 @@ func FormatPartitionsByStatus(
 
 	table := tablewriter.NewWriter(buf)
 	table.SetHeader(headers)
-	table.SetAutoWrapText(false)
+	table.SetAutoWrapText(true)
 	table.SetColumnAlignment(colAlignment)
 	table.SetBorders(
 		tablewriter.Border{

--- a/pkg/admin/format.go
+++ b/pkg/admin/format.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
-	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/topicctl/pkg/util"
 )
 
@@ -888,7 +887,7 @@ func maxMapValues(inputMap map[int]int) int {
 
 // FormatPartitionsByStatus creates a pretty table that lists the details of the partitions by status
 func FormatPartitionsByStatus(
-	partitionsInfo map[string][]kafka.Partition,
+	partitionsInfoByStatus map[string][]PartitionStatusInfo,
 	full bool,
 ) string {
 	buf := &bytes.Buffer{}
@@ -934,23 +933,23 @@ func FormatPartitionsByStatus(
 		},
 	)
 
-	for topicName, partitions := range partitionsInfo {
+	for topicName, partitionsStatusInfo := range partitionsInfoByStatus {
 		if full {
-			for _, partition := range partitions {
+			for _, partitionStatusInfo := range partitionsStatusInfo {
 				partitionIsrs := []int{}
-				for _, partitionStatusIsr := range partition.Isr {
+				for _, partitionStatusIsr := range partitionStatusInfo.Partition.Isr {
 					partitionIsrs = append(partitionIsrs, partitionStatusIsr.ID)
 				}
 
 				partitionReplicas := []int{}
-				for _, partitionReplica := range partition.Replicas {
+				for _, partitionReplica := range partitionStatusInfo.Partition.Replicas {
 					partitionReplicas = append(partitionReplicas, partitionReplica.ID)
 				}
 
 				row := []string{
 					topicName,
-					fmt.Sprintf("%d", partition.ID),
-					fmt.Sprintf("%d", partition.Leader.ID),
+					fmt.Sprintf("%d", partitionStatusInfo.Partition.ID),
+					fmt.Sprintf("%d", partitionStatusInfo.Partition.Leader.ID),
 					fmt.Sprintf("%+v", partitionIsrs),
 					fmt.Sprintf("%+v", partitionReplicas),
 				}
@@ -959,8 +958,8 @@ func FormatPartitionsByStatus(
 			}
 		} else {
 			partitionIDs := []int{}
-			for _, partition := range partitions {
-				partitionIDs = append(partitionIDs, partition.ID)
+			for _, partitionStatusInfo := range partitionsStatusInfo {
+				partitionIDs = append(partitionIDs, partitionStatusInfo.Partition.ID)
 			}
 
 			row := []string{
@@ -979,7 +978,7 @@ func FormatPartitionsByStatus(
 
 // FormatPartitionsAllStatus creates a pretty table that lists all partitions status
 func FormatPartitionsAllStatus(
-	partitionsInfo map[string][]PartitionStatusInfo,
+	partitionsInfoAllStatus map[string][]PartitionStatusInfo,
 ) string {
 	buf := &bytes.Buffer{}
 
@@ -1013,27 +1012,27 @@ func FormatPartitionsAllStatus(
 		},
 	)
 
-	for topicName, partitions := range partitionsInfo {
-		for _, partition := range partitions {
+	for topicName, partitionsStatusInfo := range partitionsInfoAllStatus {
+		for _, partitionStatusInfo := range partitionsStatusInfo {
 			partitionStatusIsrs := []int{}
-			for _, partitionStatusIsr := range partition.Partition.Isr {
+			for _, partitionStatusIsr := range partitionStatusInfo.Partition.Isr {
 				partitionStatusIsrs = append(partitionStatusIsrs, partitionStatusIsr.ID)
 			}
 
 			partitionReplicas := []int{}
-			for _, partitionReplica := range partition.Partition.Replicas {
+			for _, partitionReplica := range partitionStatusInfo.Partition.Replicas {
 				partitionReplicas = append(partitionReplicas, partitionReplica.ID)
 			}
 
 			partitionStatuses := []string{}
-			for _, status := range partition.Statuses {
-				partitionStatuses = append(partitionStatuses, string(status))
+			for _, partitionStatus := range partitionStatusInfo.Statuses {
+				partitionStatuses = append(partitionStatuses, string(partitionStatus))
 			}
 
 			row := []string{
 				topicName,
-				fmt.Sprintf("%d", partition.Partition.ID),
-				fmt.Sprintf("%d", partition.Partition.Leader.ID),
+				fmt.Sprintf("%d", partitionStatusInfo.Partition.ID),
+				fmt.Sprintf("%d", partitionStatusInfo.Partition.Leader.ID),
 				fmt.Sprintf("%+v", partitionStatusIsrs),
 				fmt.Sprintf("%+v", partitionReplicas),
 				fmt.Sprintf("%s", strings.Join(partitionStatuses, ",")),

--- a/pkg/admin/types.go
+++ b/pkg/admin/types.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/topicctl/pkg/util"
 )
 
@@ -135,6 +136,25 @@ type zkChangeNotification struct {
 	Version    int    `json:"version"`
 	EntityPath string `json:"entity_path"`
 }
+
+type PartitionStatus string
+
+const (
+	UnderReplicated    PartitionStatus = "UNDER-REPLICATED"
+	Offline            PartitionStatus = "OFFLINE"
+	PreferredLeader    PartitionStatus = "PREFERRED-LEADER"
+	NotPreferredLeader PartitionStatus = "NOT-PREFERRED-LEADER"
+)
+
+type PartitionStatusInfo struct {
+	Topic     string
+	Partition kafka.Partition
+	Statuses  []PartitionStatus
+}
+
+const (
+	ListenerNotFoundError kafka.Error = 72
+)
 
 // Addr returns the address of the current BrokerInfo.
 func (b BrokerInfo) Addr() string {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -770,8 +770,8 @@ func getPartitionsStatus(
 // NOTE: partition is
 // 1. offline - if ListenerNotFound Error observed for leader partition
 // 2. underreplicated - if number of isrs are lesser than the replicas
-// 3. preferred leader - if the leader partition broker id is similar to first valid Replicas broker id
-// 4. not preferred leader - if the leader partitions broker id is not similar to first valid Replicas broker id
+// 3. preferred leader - if the leader partition broker id is similar to first available Replicas broker id
+// 4. not preferred leader - if the leader partitions broker id is not similar to first available Replicas broker id
 func GetPartitionStatuses(partition kafka.Partition) []admin.PartitionStatus {
 	//
 	// NOTE:

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -601,7 +601,7 @@ func (c *CLIRunner) GetPartitionsStatus(
 	c.stopSpinner()
 	log.Debugf("kafka-go metadata response: %v", metadata)
 
-	partitionsInfoAllStatus := getPartitionsStatus(topics, metadata)
+	partitionsInfoAllStatus := GetPartitionsStatusInfo(topics, metadata)
 	log.Debugf("partitionsInfoAllStatus: %v", partitionsInfoAllStatus)
 	if status == "" {
 		c.printer(
@@ -671,7 +671,7 @@ func (c *CLIRunner) GetAllTopicsMetaData(
 }
 
 // This is the actual function where we fetch all the topic partitions with status
-func getPartitionsStatus(
+func GetPartitionsStatusInfo(
 	topics []string,
 	metadata *kafka.MetadataResponse,
 ) map[string][]admin.PartitionStatusInfo {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -777,15 +777,16 @@ func GetPartitionStatuses(partition kafka.Partition) []admin.PartitionStatus {
 	//
 	// NOTE:
 	// In general, partition error precedence is
-	// Offline > UnderReplicated > PreferredLeader > NotPreferredLeader
+	// Offline > UnderReplicated > NotPreferredLeader
 	//
-	// BUT offline partition triumps everything
+	// BUT offline partition triumphs everything
 	//
 	// Examples:
 	// - An under replicated can be preferredleader or not a preferred leader
 	// - An offline partition is NOT under replicated since there are no isrs
 	// Gotcha: what if offline partition has ISRs? Not sure how to replicate this
 	//
+
 	statuses := []admin.PartitionStatus{}
 
 	// check offline. If offline, return the statuses


### PR DESCRIPTION
# Description
This PR is to add new action: `partitions-status` for topicctl get

## Expectations:
- topicctl get partitions-status (optional --topics flag)
- topicctl get partitions-status --status <offline|under-replicated|preferred-leader|not-preferred-leader> (optional --topics flag)
- topicctl get partitions-status --status <offline|under-replicated|preferred-leader|not-preferred-leader> --full (optional --topics flag)

## partitions-status - Under replicated partitions:
Kafka cluster is in under replicated state if the number of ISR are less than the Replicas available for the partition

## partitions-status - Offline partitions: 
Kafka cluster is in offline state if partition leader broker ID is not found. (i.e) kafka-go metadata call with partitions having ListenerNotFound Error observed for leader partition

Gotcha: what if offline partition has valid ISRs? Not sure how to replicate this! No matter what, Partition is offline is there is no Leader broker ID

## partitions-status - Preferred Leader partitions:
if the leader partition broker id is equal to first available Replicas broker id

## partitions-status - Not Preferred Leader partitions:
if the leader partition broker id is not equal to first available Replicas broker id

### NOTE:
- We leverage kafka-go metadata for all the above partitions statuses
- Unlike sarama which gives the offline leader broker id as -1, kafka-go gives the offline broker id as 0 (also Port is 0 with Partition Error information etc)
- To make readability better for users, we will modify broker ID from:
- - any ISR broker ID that does not have valid Host or Port from 0 to -1
- - any Replica broker ID that does not have valid Host or Port from 0 to -1
- - (Offline) Leader Broker ID that does not have a valid Host or Port from 0 to -1
- In general, partition error precedence is - Offline > UnderReplicated > NotPreferredLeader. BUT offline partition triumphs everything

----

# Local Set UP Details:
- Set up type: Docker
- Number of Kafka Nodes: 3 (one in each rack). Broker IDs - 0,1,2 running on ports 19092, 29092, 39092. Kafka containers are kafka-1 (broker ID-0), kafka-2(broker ID-1), kafka-3(broker ID-2)
- Number of zookeeper Nodes: 1, running on port 12181
- A Mock Producer produces to topic: test-1
- A Mock Consumer reads from topic: test-1
- `topic: __consumer_offsets` - partitions: 50, replication: 3, strategy - any
- `topic: test-1` - partitions 1, replication 3, strategy - any
- `topic: threepartition`  - partitions 3, replication 2, strategy - Fixed placement. We will have partitions 0,1 spread in brokers 1,2, partition 2 in brokers 0,1

----

## Build
- Build to run locally - `go build -o ./build/topicctl -a ./cmd/topicctl`
- Build to run inside container `GOOS=linux GOARCH=amd64 go build -o ./build/topicctl-linux-amd64 -a ./cmd/topicctl`

----

## (Used later) Copy the amd64 build to zookeeper docker
- `docker cp ./build/topicctl-linux-amd64 zookeeper:/tmp`

## Run help
`#./build/topicctl get partitions-status --help`

<img width="1729" alt="Screenshot 2023-09-18 at 21 25 23" src="https://github.com/segmentio/topicctl/assets/105226401/1db0b52e-9a13-4d8b-a7e8-2950267ba6b7">

----

## Get all partitions-status via kafka broker url
`# ./build/topicctl get partitions-status --broker-addr localhost:29092`

<img width="1725" alt="Screenshot 2023-09-18 at 21 27 07" src="https://github.com/segmentio/topicctl/assets/105226401/2c96fe57-6ae3-4a76-9ad5-79421fa8331a">
<img width="1731" alt="Screenshot 2023-09-18 at 21 27 41" src="https://github.com/segmentio/topicctl/assets/105226401/704c3cfb-9187-418e-9cd8-0338b3808e52">

----

## Get all partitions-status via kafka broker url --full 
NOTE: --full flag is not applicable to partitions-status
<img width="1726" alt="Screenshot 2023-09-18 at 21 28 57" src="https://github.com/segmentio/topicctl/assets/105226401/be68d360-b62f-4814-a6a8-d1e17fa0ee09">
<img width="1723" alt="Screenshot 2023-09-18 at 21 29 18" src="https://github.com/segmentio/topicctl/assets/105226401/1c29d4ad-30fe-432d-b927-4d5b485a4749">

----

## Run the same command with `--zk-addr`
NOTE: since this is local set up, we will build an run this inside the zookeeper. Because zookeeper stores the kafka Broker name information and network can get tricky with Docker from local machine
`# docker exec -u root -it zookeeper /tmp/topicctl-linux-amd64 get partitions-status --zk-addr localhost:2181`

<img width="1727" alt="Screenshot 2023-09-18 at 21 37 01" src="https://github.com/segmentio/topicctl/assets/105226401/8d39ca3b-e772-477a-b6d1-b903ed32babe">
<img width="1729" alt="Screenshot 2023-09-18 at 21 37 23" src="https://github.com/segmentio/topicctl/assets/105226401/c97b7740-c4c1-47fa-9a7e-c8c9c981fadf">

----

## Partitions Information (created a topic threepartition)
<img width="1687" alt="Screenshot 2023-09-18 at 21 52 17" src="https://github.com/segmentio/topicctl/assets/105226401/a524388c-a1f3-42b0-a17f-569ef5c13331">

----
## `topic: threepartition` information
If you observe, partitions 0,1 replicas are in brokers 1, 2
<img width="1681" alt="Screenshot 2023-09-18 at 21 52 34" src="https://github.com/segmentio/topicctl/assets/105226401/b0360c27-5af4-4cbe-98d3-e14ee1ab9f18">

----

## Get all partitions-status via --zk-addr
`# docker exec -u root -it zookeeper /tmp/topicctl-linux-amd64 get partitions-status --zk-addr localhost:2181`
<img width="1722" alt="Screenshot 2023-09-18 at 21 54 27" src="https://github.com/segmentio/topicctl/assets/105226401/4b9f8983-73f1-4a0e-b180-7183d46de97c">
<img width="1727" alt="Screenshot 2023-09-18 at 21 54 44" src="https://github.com/segmentio/topicctl/assets/105226401/4c36a749-05d9-457c-b5f8-0d7e60f60700">

----

## Get preferred-leader partitions only
`# docker exec -u root -it zookeeper /tmp/topicctl-linux-amd64 get partitions-status --zk-addr localhost:2181 --status preferred-leader`
<img width="1727" alt="Screenshot 2023-09-18 at 21 55 49" src="https://github.com/segmentio/topicctl/assets/105226401/bec31316-3864-41e9-8eb7-a9fe5d45b1de">

----

## Get preferred-leader partitions --full mode
`# ./build/topicctl get partitions-status --broker-addr localhost:39092 --status preferred-leader --full`
<img width="1725" alt="Screenshot 2023-09-18 at 21 56 30" src="https://github.com/segmentio/topicctl/assets/105226401/746eb950-6829-4cd2-b17f-f594b09142f5">
<img width="1723" alt="Screenshot 2023-09-18 at 21 56 44" src="https://github.com/segmentio/topicctl/assets/105226401/0ef62238-e1a7-49e6-b814-4ef10b7b4b8b">

----

## Get preferred-leader partitions --topics test-1,threepartition
`# ./build/topicctl get partitions-status --broker-addr localhost:39092 --status preferred-leader --full --topics test-1,threepartition`
`# ./build/topicctl get partitions-status --broker-addr localhost:39092 --status preferred-leader --topics test-1,threepartition`
<img width="1728" alt="Screenshot 2023-09-18 at 21 59 00" src="https://github.com/segmentio/topicctl/assets/105226401/5bba9ed0-3f17-41f9-a56f-08913e1aef00">

----

## Get Under replicated partitions
`# docker exec -u root -it zookeeper /tmp/topicctl-linux-amd64 get partitions-status --zk-addr localhost:2181 --status under-replicated`
`# docker exec -u root -it zookeeper /tmp/topicctl-linux-amd64 get partitions-status --zk-addr localhost:2181 --status under-replicated --full`

<img width="1728" alt="Screenshot 2023-09-18 at 22 00 26" src="https://github.com/segmentio/topicctl/assets/105226401/5a32def6-95bf-42b4-9786-0957859f3ee4">

----

## Kill Broker IDs 1, 2
`# docker stop kafka-2; docker stop kafka-3`

----
## Getting all partition status (via --zk-addr)
`# docker exec -u root -it zookeeper /tmp/topicctl-linux-amd64 get partitions-status --zk-addr localhost:2181`

<img width="1728" alt="Screenshot 2023-09-18 at 22 05 08" src="https://github.com/segmentio/topicctl/assets/105226401/05f0eb04-c3ed-4f3a-b949-71e26b9dea4e">

<img width="1731" alt="Screenshot 2023-09-18 at 22 05 23" src="https://github.com/segmentio/topicctl/assets/105226401/69e87098-6b44-4596-91c4-3ed346b73710">

----

## Get all under-replicated partitions (via broker-addr)
`# ./build/topicctl get partitions-status --broker-addr localhost:19092 --status preferred-leader`
`# ./build/topicctl get partitions-status --broker-addr localhost:19092 --status preferred-leader --full`

<img width="1728" alt="Screenshot 2023-09-18 at 22 07 15" src="https://github.com/segmentio/topicctl/assets/105226401/fc5c72dd-0efc-4e71-a2b3-5183d8150ed4">

<img width="1721" alt="Screenshot 2023-09-18 at 22 07 32" src="https://github.com/segmentio/topicctl/assets/105226401/8f712020-1328-471e-bf99-04490e4d9e1c">

----

## Get all offline partitions (via --zk-addr)

`# docker exec -u root -it zookeeper /tmp/topicctl-linux-amd64 get partitions-status --zk-addr localhost:2181 --status offline`
`# docker exec -u root -it zookeeper /tmp/topicctl-linux-amd64 get partitions-status --zk-addr localhost:2181 --status offline --full`

<img width="1722" alt="Screenshot 2023-09-18 at 22 08 29" src="https://github.com/segmentio/topicctl/assets/105226401/ce6260d2-f34b-46ba-a3d4-af6ee0d4f72a">

----

## Get all preferred leader (via kafka broker-addr) filter for topics __consumer_offsets

`# ./build/topicctl get partitions-status --broker-addr localhost:19092 --status preferred-leader --topics __consumer_offsets`
`# ./build/topicctl get partitions-status --broker-addr localhost:19092 --status preferred-leader --topics __consumer_offsets --full`

<img width="1729" alt="Screenshot 2023-09-18 at 22 10 18" src="https://github.com/segmentio/topicctl/assets/105226401/2c242421-49dd-44f6-98c6-59e395bc3ed7">

<img width="1721" alt="Screenshot 2023-09-18 at 22 10 33" src="https://github.com/segmentio/topicctl/assets/105226401/7891905a-6900-446a-97f4-26b415698c8e">

----

## Start Broker IDs 1, 2
`# docker start kafka-2; docker start kafka-3`

----

## Get all partition Status
`# ./build/topicctl get partitions-status --broker-addr localhost:29092`

<img width="1726" alt="Screenshot 2023-09-18 at 22 13 18" src="https://github.com/segmentio/topicctl/assets/105226401/f702a108-d2fd-44c3-bca5-b2687006c6b1">

<img width="1726" alt="Screenshot 2023-09-18 at 22 13 48" src="https://github.com/segmentio/topicctl/assets/105226401/0f1482df-c3f8-4ccb-b726-b718ed83e1a0">


---

## Get Not Preferred Leader partitions

`# ./build/topicctl get partitions-status --broker-addr localhost:29092 --status not-preferred-leader `
`# ./build/topicctl get partitions-status --broker-addr localhost:29092 --status not-preferred-leader --full`

<img width="1724" alt="Screenshot 2023-09-18 at 22 14 50" src="https://github.com/segmentio/topicctl/assets/105226401/96460083-b99c-41e0-9730-d33766481e1f">

<img width="1725" alt="Screenshot 2023-09-18 at 22 15 03" src="https://github.com/segmentio/topicctl/assets/105226401/ac1e0fd4-7c7f-4d79-bcf0-c9fc78e53cdf">

