### PR TITLE
stop flaky test failures

### DIFF
--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -455,6 +455,25 @@ func TestBrokerClientAlterAssignments(t *testing.T) {
 		topicInfo, err = client.GetTopic(ctx, topicName, true)
 		require.NoError(t, err)
 
+		// Alter partition succeeded
+		if topicInfo.Partitions[2].Replicas[0] != 5 {
+			return fmt.Errorf("Assign partitions change not reflected yet")
+		}
+
+		for _, partition := range topicInfo.Partitions {
+			if len(partition.Replicas) != 2 {
+				return fmt.Errorf("Assign partitions change not reflected yet")
+			}
+		}
+
+		return nil
+	})
+
+	util.RetryUntil(t, 5*time.Second, func() error {
+		topicInfo, err = client.GetTopic(ctx, topicName, true)
+		require.NoError(t, err)
+
+		// ISR shrink completed
 		for _, partition := range topicInfo.Partitions {
 			if len(partition.Replicas) != 2 {
 				return fmt.Errorf("Assign partitions change not reflected yet")

--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -460,12 +460,6 @@ func TestBrokerClientAlterAssignments(t *testing.T) {
 			return fmt.Errorf("Assign partitions change not reflected yet")
 		}
 
-		for _, partition := range topicInfo.Partitions {
-			if len(partition.Replicas) != 2 {
-				return fmt.Errorf("Assign partitions change not reflected yet")
-			}
-		}
-
 		return nil
 	})
 

--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -455,15 +455,14 @@ func TestBrokerClientAlterAssignments(t *testing.T) {
 		topicInfo, err = client.GetTopic(ctx, topicName, true)
 		require.NoError(t, err)
 
-		if topicInfo.Partitions[2].Replicas[0] != 5 {
-			return fmt.Errorf("Assign partitions change not reflected yet")
+		for _, partition := range topicInfo.Partitions {
+			if len(partition.Replicas) != 2 {
+				return fmt.Errorf("Assign partitions change not reflected yet")
+			}
 		}
 
 		return nil
 	})
-
-	// TODO: Replace this with some sort of retry until.
-	time.Sleep(time.Second)
 
 	assert.Equal(
 		t,

--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -432,6 +433,8 @@ func TestBrokerClientAlterAssignments(t *testing.T) {
 		_, err := client.GetTopic(ctx, topicName, true)
 		return err
 	})
+
+	time.Sleep(250 * time.Millisecond)
 
 	err = client.AssignPartitions(
 		ctx,

--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"

--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -460,13 +460,6 @@ func TestBrokerClientAlterAssignments(t *testing.T) {
 			return fmt.Errorf("Assign partitions change not reflected yet")
 		}
 
-		return nil
-	})
-
-	util.RetryUntil(t, 5*time.Second, func() error {
-		topicInfo, err = client.GetTopic(ctx, topicName, true)
-		require.NoError(t, err)
-
 		// ISR shrink completed
 		for _, partition := range topicInfo.Partitions {
 			if len(partition.Replicas) != 2 {

--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -433,8 +433,6 @@ func TestBrokerClientAlterAssignments(t *testing.T) {
 		return err
 	})
 
-	time.Sleep(250 * time.Millisecond)
-
 	err = client.AssignPartitions(
 		ctx,
 		topicName,
@@ -463,6 +461,9 @@ func TestBrokerClientAlterAssignments(t *testing.T) {
 
 		return nil
 	})
+
+	// TODO: Replace this with some sort of retry until.
+	time.Sleep(time.Second)
 
 	assert.Equal(
 		t,


### PR DESCRIPTION
TestBrokerClientAlterAssignments appears to fail quite often ([1](https://github.com/segmentio/topicctl/actions/runs/6472883702/job/17574399170), [2](https://github.com/segmentio/topicctl/actions/runs/6474554914/job/17579712456)) due to ISRs not shrinking before the test completes. This PR improves the retry check to see if ISRs have shrunk to their expected value