### PR TITLE
Ssingudasu/fixtures invalid bounds in offsets

### DIFF
--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -145,7 +145,7 @@ func FormatBounds(boundsSlice []Bounds) string {
 	)
 
 	for _, bounds := range boundsSlice {
-		if bounds.FirstOffset == bounds.LastOffset {
+		if bounds.FirstOffset == bounds.LastOffset && bounds.Messages == 0 {
 			table.Append(
 				[]string{
 					fmt.Sprintf("%d", bounds.Partition),
@@ -159,7 +159,6 @@ func FormatBounds(boundsSlice []Bounds) string {
 				},
 			)
 		} else {
-			numMessages := bounds.LastOffset - bounds.FirstOffset + 1
 			duration := bounds.LastTime.Sub(bounds.FirstTime)
 
 			table.Append(
@@ -169,9 +168,9 @@ func FormatBounds(boundsSlice []Bounds) string {
 					bounds.FirstTime.Format(time.RFC3339),
 					fmt.Sprintf("%d", bounds.LastOffset),
 					bounds.LastTime.Format(time.RFC3339),
-					fmt.Sprintf("%d", numMessages),
+					fmt.Sprintf("%d", bounds.Messages),
 					util.PrettyDuration(duration),
-					util.PrettyRate(numMessages, duration),
+					util.PrettyRate(bounds.Messages, duration),
 				},
 			)
 		}
@@ -221,8 +220,8 @@ func FormatBoundTotals(boundsSlice []Bounds) string {
 	var latestTime time.Time
 
 	for _, bounds := range boundsSlice {
-		if bounds.FirstOffset < bounds.LastOffset {
-			totalMessages += bounds.LastOffset - bounds.FirstOffset + 1
+		if bounds.Messages != 0 {
+			totalMessages += bounds.Messages
 
 			if earliestTime.IsZero() {
 				earliestTime = bounds.FirstTime

--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -159,7 +159,7 @@ func FormatBounds(boundsSlice []Bounds) string {
 				},
 			)
 		} else {
-			numMessages := bounds.LastOffset - bounds.FirstOffset
+			numMessages := bounds.LastOffset - bounds.FirstOffset + 1
 			duration := bounds.LastTime.Sub(bounds.FirstTime)
 
 			table.Append(
@@ -222,7 +222,7 @@ func FormatBoundTotals(boundsSlice []Bounds) string {
 
 	for _, bounds := range boundsSlice {
 		if bounds.FirstOffset < bounds.LastOffset {
-			totalMessages += bounds.LastOffset - bounds.FirstOffset
+			totalMessages += bounds.LastOffset - bounds.FirstOffset + 1
 
 			if earliestTime.IsZero() {
 				earliestTime = bounds.FirstTime


### PR DESCRIPTION
# Description:

kafka-go library conn.ReadOffsets() has following outcomes
- no messages in topic
	   conn.ReadOffsets() -> firstOffset = 0, lastOffset = 0
- 1 message in topic (before retention.ms)
	   conn.ReadOffsets() -> firstOffset = 0, lastOffset = 1
- 2 messages in topic (before retention.ms)
	   conn.ReadOffsets() -> firstOffset = 0, lastOffset = 2
---

kafka-go library connector.KafkaClient.ConsumerOffsets()
- returns offsets for partitions as -1 for for a consumergroup of a topic with no messages

---

If we push 10 messages to a new topic, offsets start from 0 to 9. There is a need
to distinguish no messages in topic to a single message in topic

---

Hence we will return the first and last offset as -1 for topic with no messages