### PR TITLE
topicctl bug fix for offsets

### DIFF
--- a/pkg/groups/groups.go
+++ b/pkg/groups/groups.go
@@ -160,6 +160,8 @@ func GetMemberLags(
 			GroupId: groupID,
 		},
 	)
+	log.Debugf("Received consumerOffsets: %+v", offsets)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/groups/groups_test.go
+++ b/pkg/groups/groups_test.go
@@ -291,7 +291,7 @@ func TestGetLags(t *testing.T) {
 
 	// We create topic with 2 partitions and send 10 messages. first, last offset for all partitions is 0
 	// When we consume 4 messages, 5 is the latest/last/newest offset
-	// We consumer 2 messages for each partition. Hence member_offset(2) <= last_offset(5)
+	// We consume 2 messages for each partition. Hence member_offset(2) <= last_offset(5)
 	for l, lag := range lags {
 		assert.Equal(t, l, lag.Partition)
 		assert.Equal(t, int64(5), lag.NewestOffset)

--- a/pkg/messages/bounds.go
+++ b/pkg/messages/bounds.go
@@ -179,7 +179,7 @@ func GetPartitionBounds(
 			"Moving first offset forward to match min offset (%d)",
 			minOffset,
 		)
-		firstOffset = minOffset
+		firstOffset = minOffset - 1
 	}
 
 	var firstMessage kafka.Message
@@ -233,11 +233,18 @@ func GetPartitionBounds(
 		)
 	}
 
+	log.Debugf(
+		"Final offsets for %d: %d->%d",
+		partition,
+		firstMessage.Offset,
+		lastMessage.Offset,
+	)
+
 	return Bounds{
 		Partition:   partition,
 		FirstOffset: firstMessage.Offset,
 		FirstTime:   firstMessage.Time,
-		LastOffset:  lastMessage.Offset,
+		LastOffset:  lastMessage.Offset + 1,
 		LastTime:    lastMessage.Time,
 	}, nil
 }

--- a/pkg/messages/bounds.go
+++ b/pkg/messages/bounds.go
@@ -175,11 +175,21 @@ func GetPartitionBounds(
 	}
 
 	if minOffset > firstOffset {
-		log.Debugf(
-			"Moving first offset forward to match min offset (%d)",
-			minOffset,
-		)
-		firstOffset = minOffset - 1
+		// if minOffset is equal to lastOffset
+		// We read message (firstMessage) from minOffset+1 Which can lead to invalid reads
+		// Hence, We will not move first offset to match min offset
+		if minOffset >= lastOffset {
+			log.Debugf(
+				"Not Moving first offset forward to match min offset (%d) since minOffset is equal to lastOffset",
+				minOffset,
+			)
+		} else {
+			log.Debugf(
+				"Moving first offset forward to match min offset (%d)",
+				minOffset,
+			)
+			firstOffset = minOffset
+		}
 	}
 
 	var firstMessage kafka.Message

--- a/pkg/messages/bounds.go
+++ b/pkg/messages/bounds.go
@@ -174,22 +174,15 @@ func GetPartitionBounds(
 		}, nil
 	}
 
-	if minOffset > firstOffset {
-		// if minOffset is equal to lastOffset
-		// We read message (firstMessage) from minOffset+1 Which can lead to invalid reads
-		// Hence, We will not move first offset to match min offset
-		if minOffset >= lastOffset {
-			log.Debugf(
-				"Not Moving first offset forward to match min offset (%d) since minOffset is equal to lastOffset",
-				minOffset,
-			)
-		} else {
-			log.Debugf(
-				"Moving first offset forward to match min offset (%d)",
-				minOffset,
-			)
-			firstOffset = minOffset
-		}
+	// if minOffset is equal to lastOffset
+	// We read message (firstMessage) from minOffset+1 Which can lead to invalid reads
+	// Hence, We will not move first offset to match min offset if minOffset >= lastOffset
+	if minOffset > firstOffset && minOffset < lastOffset {
+		log.Debugf(
+			"Moving first offset forward to match min offset (%d)",
+			minOffset,
+		)
+		firstOffset = minOffset
 	}
 
 	var firstMessage kafka.Message

--- a/pkg/messages/bounds_test.go
+++ b/pkg/messages/bounds_test.go
@@ -64,16 +64,16 @@ func TestGetAllPartitionBounds(t *testing.T) {
 	bounds, err := GetAllPartitionBounds(ctx, connector, topicName, nil)
 	assert.NoError(t, err)
 
-	// The first partition gets 3 messages
+	// The first partition gets 3 messages. (i.e) earliest/first offset is 0 and latest/last is 3
 	assert.Equal(t, 4, len(bounds))
 	assert.Equal(t, 0, bounds[0].Partition)
 	assert.Equal(t, int64(0), bounds[0].FirstOffset)
-	assert.Equal(t, int64(2), bounds[0].LastOffset)
+	assert.Equal(t, int64(3), bounds[0].LastOffset)
 
-	// The last partition gets only 2 messages
+	// The last partition gets only 2 messages. (i.e) earliest/first offset is 0 and latest/last is 2
 	assert.Equal(t, 3, bounds[3].Partition)
 	assert.Equal(t, int64(0), bounds[3].FirstOffset)
-	assert.Equal(t, int64(1), bounds[3].LastOffset)
+	assert.Equal(t, int64(2), bounds[3].LastOffset)
 
 	boundsWithOffsets, err := GetAllPartitionBounds(
 		ctx,
@@ -87,13 +87,13 @@ func TestGetAllPartitionBounds(t *testing.T) {
 
 	assert.Equal(t, 4, len(boundsWithOffsets))
 
-	// Start of first partition is moved forward
+	// Start of first partition is moved forward. First partition has earliest offset is 0 and latest is 3
 	assert.Equal(t, 0, boundsWithOffsets[0].Partition)
 	assert.Equal(t, int64(1), boundsWithOffsets[0].FirstOffset)
-	assert.Equal(t, int64(2), boundsWithOffsets[0].LastOffset)
+	assert.Equal(t, int64(3), boundsWithOffsets[0].LastOffset)
 
-	// Other partition bounds are unchanged
+	// Other partition bounds are unchanged. Last partition has earliest offset is 0 and latest is 2
 	assert.Equal(t, 3, boundsWithOffsets[3].Partition)
 	assert.Equal(t, int64(0), boundsWithOffsets[3].FirstOffset)
-	assert.Equal(t, int64(1), boundsWithOffsets[3].LastOffset)
+	assert.Equal(t, int64(2), boundsWithOffsets[3].LastOffset)
 }


### PR DESCRIPTION
# Description:

Bug fixes for
- Current offsets for topics are off by 1
- Consumer lags are not displayed properly
- Sometimes, getting lags leads to errors - ERROR Group state is dead; check that group ID is valid

Below topicctl actions will have offset fixtures
```
# topicctl get offsets
# topicctl get lags
# topicctl reset-offsets
```