### PR TITLE
topicctl get action to fetch controllerid and clusterid

### DIFF
--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -61,6 +61,7 @@ func init() {
 		balanceCmd(),
 		brokersCmd(),
 		controllerCmd(),
+		clusterIDCmd(),
 		configCmd(),
 		groupsCmd(),
 		lagsCmd(),
@@ -137,8 +138,8 @@ func brokersCmd() *cobra.Command {
 
 func controllerCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "controller",
-		Short: "Displays active controller broker ID.",
+		Use:   "controllerid",
+		Short: "Displays active controller broker id.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -152,6 +153,27 @@ func controllerCmd() *cobra.Command {
 
 			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetControllerID(ctx, getConfig.full)
+		},
+	}
+}
+
+func clusterIDCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clusterid",
+		Short: "Displays cluster id.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
+			if err != nil {
+				return err
+			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
+			return cliRunner.GetClusterID(ctx, getConfig.full)
 		},
 	}
 }

--- a/cmd/topicctl/subcmd/get.go
+++ b/cmd/topicctl/subcmd/get.go
@@ -60,6 +60,7 @@ func init() {
 	getCmd.AddCommand(
 		balanceCmd(),
 		brokersCmd(),
+		controllerCmd(),
 		configCmd(),
 		groupsCmd(),
 		lagsCmd(),
@@ -130,6 +131,27 @@ func brokersCmd() *cobra.Command {
 
 			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
 			return cliRunner.GetBrokers(ctx, getConfig.full)
+		},
+	}
+}
+
+func controllerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "controller",
+		Short: "Displays active controller broker ID.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			sess := session.Must(session.NewSession())
+
+			adminClient, err := getConfig.shared.getAdminClient(ctx, sess, true)
+			if err != nil {
+				return err
+			}
+			defer adminClient.Close()
+
+			cliRunner := cli.NewCLIRunner(adminClient, log.Infof, !noSpinner)
+			return cliRunner.GetControllerID(ctx, getConfig.full)
 		},
 	}
 }

--- a/pkg/admin/brokerclient.go
+++ b/pkg/admin/brokerclient.go
@@ -232,6 +232,19 @@ func (c *BrokerAdminClient) GetBrokers(ctx context.Context, ids []int) (
 	return brokerInfos, nil
 }
 
+// GetControllerID gets ID of the active controller broker
+func (c *BrokerAdminClient) GetControllerID(ctx context.Context) (
+	int,
+	error,
+) {
+	metadataResp, err := c.getMetadata(ctx, nil)
+	if err != nil {
+		return -1, err
+	}
+
+	return metadataResp.Controller.ID, nil
+}
+
 // GetBrokerIDs get the IDs of all brokers in the cluster.
 func (c *BrokerAdminClient) GetBrokerIDs(ctx context.Context) ([]int, error) {
 	resp, err := c.getMetadata(ctx, nil)

--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -13,6 +13,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBrokerClientControllerID(t *testing.T) {
+	if !util.CanTestBrokerAdmin() {
+		t.Skip("Skipping because KAFKA_TOPICS_TEST_BROKER_ADMIN is not set")
+	}
+
+	ctx := context.Background()
+	client, err := NewBrokerAdminClient(
+		ctx,
+		BrokerAdminClientConfig{
+			ConnectorConfig: ConnectorConfig{
+				BrokerAddr: util.TestKafkaAddr(),
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	brokerIDs, err := client.GetBrokerIDs(ctx)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		[]int{1, 2, 3, 4, 5, 6},
+		brokerIDs,
+	)
+
+	controllerID, err := client.GetControllerID(ctx)
+	require.NoError(t, err)
+	assert.Condition(t, func() bool {
+		return controllerID >= 1 && controllerID <= 6
+	}, fmt.Sprintf("Received %d, Broker Controller ID should be between 1 and 6.", controllerID))
+}
+
 func TestBrokerClientGetClusterID(t *testing.T) {
 	if !util.CanTestBrokerAdmin() {
 		t.Skip("Skipping because KAFKA_TOPICS_TEST_BROKER_ADMIN is not set")

--- a/pkg/admin/client.go
+++ b/pkg/admin/client.go
@@ -15,6 +15,9 @@ type Client interface {
 	// GetBrokers gets information about all brokers in the cluster.
 	GetBrokers(ctx context.Context, ids []int) ([]BrokerInfo, error)
 
+	// GetControllerID get the active controller broker ID in the cluster.
+	GetControllerID(ctx context.Context) (int, error)
+
 	// GetBrokerIDs get the IDs of all brokers in the cluster.
 	GetBrokerIDs(ctx context.Context) ([]int, error)
 

--- a/pkg/admin/format.go
+++ b/pkg/admin/format.go
@@ -108,6 +108,35 @@ func FormatBrokers(brokers []BrokerInfo, full bool) string {
 	return string(bytes.TrimRight(buf.Bytes(), "\n"))
 }
 
+// FormatControllerID creates a pretty table from a list of brokers.
+func FormatControllerID(brokerID int) string {
+	buf := &bytes.Buffer{}
+	table := tablewriter.NewWriter(buf)
+	headers := []string{"Active Controller"}
+	table.SetHeader(headers)
+
+	table.SetColumnAlignment(
+		[]int{
+			tablewriter.ALIGN_LEFT,
+		},
+	)
+	table.SetBorders(
+		tablewriter.Border{
+			Left:   false,
+			Top:    true,
+			Right:  false,
+			Bottom: true,
+		},
+	)
+
+	table.Append([]string{
+		fmt.Sprintf("%d", brokerID),
+	})
+
+	table.Render()
+	return string(bytes.TrimRight(buf.Bytes(), "\n"))
+}
+
 // FormatBrokerReplicas creates a pretty table that shows how many replicas are in each
 // position (i.e., leader, second, third) by broker across all topics. Useful for showing
 // total-topic balance.

--- a/pkg/admin/format.go
+++ b/pkg/admin/format.go
@@ -108,7 +108,7 @@ func FormatBrokers(brokers []BrokerInfo, full bool) string {
 	return string(bytes.TrimRight(buf.Bytes(), "\n"))
 }
 
-// FormatControllerID creates a pretty table from a list of brokers.
+// FormatControllerID creates a pretty table for controller broker.
 func FormatControllerID(brokerID int) string {
 	buf := &bytes.Buffer{}
 	table := tablewriter.NewWriter(buf)
@@ -131,6 +131,35 @@ func FormatControllerID(brokerID int) string {
 
 	table.Append([]string{
 		fmt.Sprintf("%d", brokerID),
+	})
+
+	table.Render()
+	return string(bytes.TrimRight(buf.Bytes(), "\n"))
+}
+
+// FormatClusterID creates a pretty table for cluster ID.
+func FormatClusterID(clusterID string) string {
+	buf := &bytes.Buffer{}
+	table := tablewriter.NewWriter(buf)
+	headers := []string{"Kafka Cluster ID"}
+	table.SetHeader(headers)
+
+	table.SetColumnAlignment(
+		[]int{
+			tablewriter.ALIGN_LEFT,
+		},
+	)
+	table.SetBorders(
+		tablewriter.Border{
+			Left:   false,
+			Top:    true,
+			Right:  false,
+			Bottom: true,
+		},
+	)
+
+	table.Append([]string{
+		clusterID,
 	})
 
 	table.Render()

--- a/pkg/admin/types.go
+++ b/pkg/admin/types.go
@@ -356,6 +356,12 @@ type zkClusterID struct {
 	ID      string `json:"id"`
 }
 
+type zkControllerInfo struct {
+	Version    int    `json:"version"`
+	BrokerID   int    `json:"brokerid"`
+	Timestamp  string `json:"timestamp"`
+}
+
 type zkBrokerInfo struct {
 	Endpoints    []string `json:"endpoints"`
 	Host         string   `json:"host"`

--- a/pkg/admin/zkclient.go
+++ b/pkg/admin/zkclient.go
@@ -305,7 +305,7 @@ func (c *ZKAdminClient) GetControllerID(
 	var dataMap map[string]interface{}
 	data, _, err := c.zkClient.Get(ctx, zkControllerPath)
 	if err != nil {
-		return -1, fmt.Errorf("Error getting zookeeper path: %s, error: %+v",
+		return -1, fmt.Errorf("Error getting zookeeper path %s: %+v",
 			zkControllerPath,
 			err,
 		)
@@ -313,7 +313,7 @@ func (c *ZKAdminClient) GetControllerID(
 
 	err = json.Unmarshal(data, &dataMap)
 	if err != nil {
-		return -1, fmt.Errorf("Error unmarshaling zookeeper response", err)
+		return -1, fmt.Errorf("Error unmarshaling zookeeper response: %+v", err)
 	}
 
 	// even if interface data is of type int, it is recognized as float64
@@ -321,7 +321,7 @@ func (c *ZKAdminClient) GetControllerID(
 		return int(brokerID), nil
 	}
 
-	return -1, fmt.Errorf("Broker ID not found in zookeeper controller path: %s, error: %+v",
+	return -1, fmt.Errorf("Broker ID not found in zookeeper controller path %s: %+v",
 		zkControllerPath,
 		err,
 	)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -79,6 +79,20 @@ func (c *CLIRunner) GetBrokers(ctx context.Context, full bool) error {
 	return nil
 }
 
+// Get active controller broker ID
+func (c *CLIRunner) GetControllerID(ctx context.Context, full bool) error {
+	c.startSpinner()
+
+	brokerID, err := c.adminClient.GetControllerID(ctx)
+	c.stopSpinner()
+	if err != nil {
+		return err
+	}
+
+	c.printer("Broker ID:\n%s", admin.FormatControllerID(brokerID))
+	return nil
+}
+
 // ApplyTopic does an apply run according to the spec in the argument config.
 func (c *CLIRunner) ApplyTopic(
 	ctx context.Context,

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -93,6 +93,20 @@ func (c *CLIRunner) GetControllerID(ctx context.Context, full bool) error {
 	return nil
 }
 
+// Get cluster ID
+func (c *CLIRunner) GetClusterID(ctx context.Context, full bool) error {
+	c.startSpinner()
+
+	clusterID, err := c.adminClient.GetClusterID(ctx)
+	c.stopSpinner()
+	if err != nil {
+		return err
+	}
+
+	c.printer("Cluster ID:\n%s", admin.FormatClusterID(clusterID))
+	return nil
+}
+
 // ApplyTopic does an apply run according to the spec in the argument config.
 func (c *CLIRunner) ApplyTopic(
 	ctx context.Context,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current topicctl version.
-const Version = "1.13.0"
+const Version = "1.14.0"


### PR DESCRIPTION
# Description

topicctl get action currently does not get the Kafka active controller broker id and cluster id

This PR is to implement actions `topicctl get controllerid`  and `topicctl get clusterid` for the Kafka cluster

## Usage

### build topicctl
```
# cd /path/to/topicctl
# go build -o ./build/topicctl -a ./cmd/topicctl
```

### topicctl get controllerid
```
# ./build/topicctl get controllerid --broker-addr {HOST}:{PORT}
# ./build/topicctl get controllerid --zk-addr {HOST}:{PORT}
# ./build/topicctl get controllerid --zk-addr {HOST}:{PORT} --zk-prefix {ZK_PREFIX}
```

### topicctl get clusterid
```
# ./build/topicctl get clusterid --broker-addr {HOST}:{PORT}
# ./build/topicctl get clusterid --zk-addr {HOST}:{PORT}
# ./build/topicctl get clusterid --zk-addr {HOST}:{PORT} --zk-prefix {ZK_PREFIX}
```

### local test
```
# cd /path/to/topicctl
# ./scripts/set_up_net_alias.sh
# docker-compose up -d
# KAFKA_TOPICS_TEST_BROKER_ADMIN=1 go test -count 1 -p 1 ./...
```

## NOTE:
- test cases have been implemented for GetControllerID since GetClusterID already has test cases
