### PR TITLE
[delete acls] add default value for resource pattern type

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The `delete` subcommand deletes a particular resource type in the cluster.
 Currently, the following operations are supported:
 | Subcommand      | Description |
 | --------- | ----------- |
-| `delete acl [flags]` | Deletes a single ACL in the cluster matching the provided flags |
+| `delete acls [flags]` | Deletes ACL(s) in the cluster matching the provided flags |
 
 #### get
 

--- a/cmd/topicctl/subcmd/delete.go
+++ b/cmd/topicctl/subcmd/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/topicctl/pkg/acl"
+	"github.com/segmentio/topicctl/pkg/admin"
 	"github.com/segmentio/topicctl/pkg/cli"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -54,7 +55,7 @@ func deletePreRun(cmd *cobra.Command, args []string) error {
 var deleteACLsConfig = aclsCmdConfig{
 	// This was added in a later version of Kafka, so we provide a default
 	// value to avoid breaking existing users by making this required.
-	ResourcePatternType: kafka.PatternTypeAny,
+	resourcePatternType: admin.PatternType(kafka.PatternTypeAny),
 }
 
 func deleteACLCmd() *cobra.Command {

--- a/cmd/topicctl/subcmd/delete.go
+++ b/cmd/topicctl/subcmd/delete.go
@@ -51,7 +51,11 @@ func deletePreRun(cmd *cobra.Command, args []string) error {
 	return deleteConfig.shared.validate()
 }
 
-var deleteACLsConfig = aclsCmdConfig{}
+var deleteACLsConfig = aclsCmdConfig{
+	// This was added in a later version of Kafka, so we provide a default
+	// value to avoid breaking existing users by making this required.
+	ResourcePatternType: kafka.PatternTypeAny,
+}
 
 func deleteACLCmd() *cobra.Command {
 	cmd := &cobra.Command{


### PR DESCRIPTION
We cannot mark the `resource-pattern-type` flag as required since it was added in later versions of Kafka, so we provide a default value of any that will get ignored in older versions of Kafka