### PR TITLE
support consumer groups in tail config

### DIFF
--- a/cmd/topicctl/subcmd/tail.go
+++ b/cmd/topicctl/subcmd/tail.go
@@ -26,6 +26,7 @@ type tailCmdConfig struct {
 	partitions []int
 	raw        bool
 	headers    bool
+	groupID    string
 
 	shared sharedOptions
 }
@@ -56,6 +57,12 @@ func init() {
 		"headers",
 		true,
 		"Output message headers",
+	)
+	tailCmd.Flags().StringVar(
+		&tailConfig.groupID,
+		"group-id",
+		"",
+		"Consumer group ID to tail with",
 	)
 
 	addSharedFlags(tailCmd, &tailConfig.shared)
@@ -97,6 +104,7 @@ func tailRun(cmd *cobra.Command, args []string) error {
 		"",
 		tailConfig.raw,
 		tailConfig.headers,
+		tailConfig.groupID,
 	)
 }
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -657,9 +657,11 @@ func (c *CLIRunner) Tail(
 	filterRegexp string,
 	raw bool,
 	headers bool,
+	groupID string,
 ) error {
 	var err error
-	if len(partitions) == 0 {
+
+	if groupID == "" && len(partitions) == 0 {
 		topicInfo, err := c.adminClient.GetTopic(ctx, topic, false)
 		if err != nil {
 			return err
@@ -672,6 +674,7 @@ func (c *CLIRunner) Tail(
 	tailer := messages.NewTopicTailer(
 		c.adminClient.GetConnector(),
 		topic,
+		groupID,
 		partitions,
 		offset,
 		10e3,

--- a/pkg/cli/repl.go
+++ b/pkg/cli/repl.go
@@ -410,6 +410,7 @@ func (r *Repl) executor(in string) {
 			filterRegexp,
 			command.getBoolValue("raw"),
 			command.getBoolValue("headers"),
+			command.flags["group_id"],
 		)
 		if err != nil {
 			log.Errorf("Error: %+v", err)


### PR DESCRIPTION
Support consumer groups in tail.

Adds an argument to `topicctl tail` to support a consumer group `--group-id`. If set, this disables the partitions command is  passed down to the reader.

I also updated `repl` with this. 

I'm happy to write a test for this but would love some instruction on the preferred way to do so in this repo.