### PR TITLE
fix: sasl validation

### DIFF
--- a/cmd/topicctl/subcmd/shared.go
+++ b/cmd/topicctl/subcmd/shared.go
@@ -97,7 +97,7 @@ func (s sharedOptions) validate() error {
 			log.Warn("Username and password are ignored if using SASL AWS-MSK-IAM")
 		}
 
-		if s.saslUsername != "" || s.saslPassword != "" && s.saslSecretsManagerArn != "" {
+		if (s.saslUsername != "" || s.saslPassword != "") && s.saslSecretsManagerArn != "" {
 			err = multierror.Append(err, errors.New("Cannot set both sasl-username or sasl-password and sasl-secrets-manager-arn"))
 		}
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current topicctl version.
-const Version = "1.14.1"
+const Version = "1.14.2"


### PR DESCRIPTION
Fixes a bug in the validation for SASL. Currently username and password cannot be provided by the command line