### PR TITLE
apply: Allow ignoring a specific error returned from  updatePartitions()

### DIFF
--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -35,6 +35,7 @@ type applyCmdConfig struct {
 	autoContinueRebalance        bool
 	retentionDropStepDurationStr string
 	skipConfirm                  bool
+	ignoreFewerPartitionsError   bool
 	sleepLoopDuration            time.Duration
 
 	shared sharedOptions
@@ -98,6 +99,12 @@ func init() {
 		"skip-confirm",
 		false,
 		"Skip confirmation prompts during apply process",
+	)
+	applyCmd.Flags().BoolVar(
+		&applyConfig.ignoreFewerPartitionsError,
+		"ignore-fewer-partitions-error",
+		false,
+		"Don't return error when topic's config specifies fewer partitions than it currently has",
 	)
 	applyCmd.Flags().DurationVar(
 		&applyConfig.sleepLoopDuration,
@@ -231,6 +238,7 @@ func applyTopic(
 			AutoContinueRebalance:      applyConfig.autoContinueRebalance,
 			RetentionDropStepDuration:  applyConfig.retentionDropStepDuration,
 			SkipConfirm:                applyConfig.skipConfirm,
+			IgnoreFewerPartitionsError: applyConfig.ignoreFewerPartitionsError,
 			SleepLoopDuration:          applyConfig.sleepLoopDuration,
 			TopicConfig:                topicConfig,
 		}


### PR DESCRIPTION
## Description
When applying topic's configuration, we'd like to be able avoid failing in case the desired topic's partitions count is smaller than the actual topic's partitions count (on the broker).
We know that Kafka doesn't allow partitions decrease so instead of failing the operation we'd like to
continue without doing anything (and make this operation idempotent, in that aspect).
This is very convenient when trying to apply a batch of topics in which case, we don't want to fail the rest of the batch for one topic that its partitions count configuration is lower than the actual partitions count. (on the broker).

This change is backward compatible, as the default behavior is kept.