### PR TITLE
feat: allow cluster labels

### DIFF
--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -27,11 +27,12 @@ type ClusterConfig struct {
 // ClusterMeta contains (mostly immutable) metadata about the cluster. Inspired
 // by the meta fields in Kubernetes objects.
 type ClusterMeta struct {
-	Name        string `json:"name"`
-	Region      string `json:"region"`
-	Environment string `json:"environment"`
-	Shard       int    `json:"shard"`
-	Description string `json:"description"`
+	Name        string            `json:"name"`
+	Region      string            `json:"region"`
+	Environment string            `json:"environment"`
+	Shard       int               `json:"shard"`
+	Description string            `json:"description"`
+	Labels      map[string]string `json:"labels"`
 }
 
 // ClusterSpec contains the details necessary to communicate with a kafka cluster.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current topicctl version.
-const Version = "1.15.0"
+const Version = "1.16.0"


### PR DESCRIPTION
Allow adding arbitrary labels to a cluster file, similar to what we can do for topics and ACLs