### PR TITLE
add ability to include internal topics in `bootstrap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ The `bootstrap` subcommand creates apply topic configs from the existing topics 
 cluster. This can be used to "import" topics not created or previously managed by topicctl.
 The output can be sent to either a directory (if the `--output` flag is set) or `stdout`.
 
+By default, this does not include internal topics such as `__consumer_offsets`.
+If you would like to have these topics included,
+pass the `--allow-internal-topics` flag.
+
 #### check
 
 ```

--- a/cmd/topicctl/subcmd/bootstrap.go
+++ b/cmd/topicctl/subcmd/bootstrap.go
@@ -21,6 +21,8 @@ type bootstrapCmdConfig struct {
 	outputDir     string
 	overwrite     bool
 
+	allowDoubleUnderscoreTopics bool
+
 	shared sharedOptions
 }
 
@@ -52,6 +54,12 @@ func init() {
 		false,
 		"Overwrite existing configs in output directory",
 	)
+	// allow topics containing double underscores
+	bootstrapCmd.Flags().BoolVar(
+		&bootstrapConfig.allowDoubleUnderscoreTopics,
+		"allow-double-underscore-topics",
+		false,
+		"Include topics that start with __ (typically these are internal topics)")
 
 	addSharedConfigOnlyFlags(bootstrapCmd, &bootstrapConfig.shared)
 	bootstrapCmd.MarkFlagRequired("cluster-config")
@@ -92,5 +100,6 @@ func bootstrapRun(cmd *cobra.Command, args []string) error {
 		bootstrapConfig.excludeRegexp,
 		bootstrapConfig.outputDir,
 		bootstrapConfig.overwrite,
+		bootstrapConfig.allowDoubleUnderscoreTopics,
 	)
 }

--- a/cmd/topicctl/subcmd/bootstrap.go
+++ b/cmd/topicctl/subcmd/bootstrap.go
@@ -21,7 +21,7 @@ type bootstrapCmdConfig struct {
 	outputDir     string
 	overwrite     bool
 
-	allowDoubleUnderscoreTopics bool
+	allowInternalTopics bool
 
 	shared sharedOptions
 }
@@ -54,10 +54,9 @@ func init() {
 		false,
 		"Overwrite existing configs in output directory",
 	)
-	// allow topics containing double underscores
 	bootstrapCmd.Flags().BoolVar(
-		&bootstrapConfig.allowDoubleUnderscoreTopics,
-		"allow-double-underscore-topics",
+		&bootstrapConfig.allowInternalTopics,
+		"allow-internal-topics",
 		false,
 		"Include topics that start with __ (typically these are internal topics)")
 
@@ -100,6 +99,6 @@ func bootstrapRun(cmd *cobra.Command, args []string) error {
 		bootstrapConfig.excludeRegexp,
 		bootstrapConfig.outputDir,
 		bootstrapConfig.overwrite,
-		bootstrapConfig.allowDoubleUnderscoreTopics,
+		bootstrapConfig.allowInternalTopics,
 	)
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -200,15 +200,7 @@ func (c *CLIRunner) DeleteACL(
 
 // BootstrapTopics creates configs for one or more topics based on their current state in the
 // cluster.
-func (c *CLIRunner) BootstrapTopics(
-	ctx context.Context,
-	topics []string,
-	clusterConfig config.ClusterConfig,
-	matchRegexpStr string,
-	excludeRegexpStr string,
-	outputDir string,
-	overwrite bool,
-) error {
+func (c *CLIRunner) BootstrapTopics(ctx context.Context, topics []string, clusterConfig config.ClusterConfig, matchRegexpStr string, excludeRegexpStr string, outputDir string, overwrite bool, allowUnderscoreTopics bool) error {
 	topicInfoObjs, err := c.adminClient.GetTopics(ctx, topics, false)
 	if err != nil {
 		return err
@@ -226,7 +218,7 @@ func (c *CLIRunner) BootstrapTopics(
 	topicConfigs := []config.TopicConfig{}
 
 	for _, topicInfo := range topicInfoObjs {
-		if strings.HasPrefix(topicInfo.Name, "__") {
+		if !allowUnderscoreTopics && strings.HasPrefix(topicInfo.Name, "__") {
 			// Never include underscore topics
 			continue
 		} else if !matchRegexp.MatchString(topicInfo.Name) {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -200,7 +200,16 @@ func (c *CLIRunner) DeleteACL(
 
 // BootstrapTopics creates configs for one or more topics based on their current state in the
 // cluster.
-func (c *CLIRunner) BootstrapTopics(ctx context.Context, topics []string, clusterConfig config.ClusterConfig, matchRegexpStr string, excludeRegexpStr string, outputDir string, overwrite bool, allowUnderscoreTopics bool) error {
+func (c *CLIRunner) BootstrapTopics(
+	ctx context.Context,
+	topics []string,
+	clusterConfig config.ClusterConfig,
+	matchRegexpStr string,
+	excludeRegexpStr string,
+	outputDir string,
+	overwrite bool,
+	allowInternalTopics bool,
+) error {
 	topicInfoObjs, err := c.adminClient.GetTopics(ctx, topics, false)
 	if err != nil {
 		return err
@@ -218,7 +227,7 @@ func (c *CLIRunner) BootstrapTopics(ctx context.Context, topics []string, cluste
 	topicConfigs := []config.TopicConfig{}
 
 	for _, topicInfo := range topicInfoObjs {
-		if !allowUnderscoreTopics && strings.HasPrefix(topicInfo.Name, "__") {
+		if !allowInternalTopics && strings.HasPrefix(topicInfo.Name, "__") {
 			// Never include underscore topics
 			continue
 		} else if !matchRegexp.MatchString(topicInfo.Name) {


### PR DESCRIPTION
- We have a tool which runs `topicctl bootstrap`, then `topicctl rebalance` in succession. 
- With this approach we are currently unable to rebalance topics such as `__consumer_offsets` since they are explicitly [not considered for bootstrap](https://github.com/segmentio/topicctl/blob/5bf428a9e5c762a6985e79a6650cff8a9aa3f4a1/pkg/cli/cli.go#L229-L231)
- This change will introduce a new flag which allows us to bootstrap these topic configurations.
- The default will be to continue current behavior of skipping double-underscore topics.

Example usage

```
topicctl bootstrap --cluster-config=... --allow-internal-topics=true --output=./topics/

[2024-05-10 17:26:47]  INFO Writing config to topics/__amazon_msk_canary.yaml
[2024-05-10 17:26:47]  INFO Writing config to topics/__consumer_offsets.yaml
[2024-05-10 17:26:47]  INFO Writing config to topics/__strimzi-topic-operator-kstreams-topic-store-changelog.yaml
[2024-05-10 17:26:47]  INFO Writing config to topics/__strimzi_store_topic.yaml
[2024-05-10 17:26:47]  INFO Skipping over existing config topics/mp-events-userid.yaml
```