### PR TITLE
fix: set admin.Connector.Dialer.SASLMechanism if TLS isn't enabled

### DIFF
--- a/pkg/admin/connector.go
+++ b/pkg/admin/connector.go
@@ -131,6 +131,7 @@ func NewConnector(config ConnectorConfig) (*Connector, error) {
 
 	if !config.TLS.Enabled {
 		connector.Dialer = kafka.DefaultDialer
+		connector.Dialer.SASLMechanism = mechanismClient
 	} else {
 		var certs []tls.Certificate
 		var caCertPool *x509.CertPool


### PR DESCRIPTION
Had an error when tried to get offsets of a topic from a cluster with enabled SASL_PLAINTEXT.
Kafka version: 2.13-3.6.1
Topicctl version: v1.17.0

```bash
topicctl get offsets topic-default \
  --broker-addr 127.0.0.1:9092 \
  --sasl-username username \
  --sasl-password password \
  --sasl-mechanism plain 

[2024-05-14 18:33:57] ERROR EOF
```