### PR TITLE
Deletes topic settings from broker if they are not present in the topic config

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,8 @@ The `apply` subcommand can make changes, but under the following conditions:
 8. Before applying, the tool checks the cluster ID against the expected value in the
   cluster config. This can help prevent errors around applying in the wrong cluster when multiple
   clusters are accessed through the same address, e.g `localhost:2181`.
+9. If the `destructive` CLI argument is passed, `apply` deletes the settings that are
+  set on the broker but not set in configuration.
 
 The `reset-offsets` command can also make changes in the cluster and should be used carefully.
 

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -36,6 +36,7 @@ type applyCmdConfig struct {
 	retentionDropStepDurationStr string
 	skipConfirm                  bool
 	ignoreFewerPartitionsError   bool
+	allowSettingsDeletion        bool
 	sleepLoopDuration            time.Duration
 	failFast                     bool
 
@@ -106,6 +107,12 @@ func init() {
 		"ignore-fewer-partitions-error",
 		false,
 		"Don't return error when topic's config specifies fewer partitions than it currently has",
+	)
+	applyCmd.Flags().BoolVar(
+		&applyConfig.allowSettingsDeletion,
+		"allow-settings-deletion",
+		false,
+		"Deletes topic settings from the broker if the setting is set on the broker but not in config",
 	)
 	applyCmd.Flags().DurationVar(
 		&applyConfig.sleepLoopDuration,
@@ -259,6 +266,7 @@ func applyTopic(
 			RetentionDropStepDuration:  applyConfig.retentionDropStepDuration,
 			SkipConfirm:                applyConfig.skipConfirm,
 			IgnoreFewerPartitionsError: applyConfig.ignoreFewerPartitionsError,
+			AllowSettingsDeletion:      applyConfig.allowSettingsDeletion,
 			SleepLoopDuration:          applyConfig.sleepLoopDuration,
 			TopicConfig:                topicConfig,
 		}

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -36,7 +36,7 @@ type applyCmdConfig struct {
 	retentionDropStepDurationStr string
 	skipConfirm                  bool
 	ignoreFewerPartitionsError   bool
-	allowSettingsDeletion        bool
+	destructive                  bool
 	sleepLoopDuration            time.Duration
 	failFast                     bool
 
@@ -109,8 +109,8 @@ func init() {
 		"Don't return error when topic's config specifies fewer partitions than it currently has",
 	)
 	applyCmd.Flags().BoolVar(
-		&applyConfig.allowSettingsDeletion,
-		"allow-settings-deletion",
+		&applyConfig.destructive,
+		"destructive",
 		false,
 		"Deletes topic settings from the broker if the setting is set on the broker but not in config",
 	)
@@ -266,8 +266,7 @@ func applyTopic(
 			RetentionDropStepDuration:  applyConfig.retentionDropStepDuration,
 			SkipConfirm:                applyConfig.skipConfirm,
 			IgnoreFewerPartitionsError: applyConfig.ignoreFewerPartitionsError,
-			AllowSettingsDeletion:      applyConfig.allowSettingsDeletion,
-			SleepLoopDuration:          applyConfig.sleepLoopDuration,
+			Destructive:                applyConfig.destructive,
 			TopicConfig:                topicConfig,
 		}
 

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -307,6 +307,7 @@ func rebalanceApplyTopic(
 		AutoContinueRebalance:      true,                      // to continue without prompts
 		RetentionDropStepDuration:  retentionDropStepDuration, // not needed for rebalance
 		SkipConfirm:                true,                      // to enforce action: rebalance
+		AllowSettingsDeletion:      false,                     // Irrelevant here
 		SleepLoopDuration:          rebalanceConfig.sleepLoopDuration,
 		TopicConfig:                topicConfig,
 	}

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -307,7 +307,7 @@ func rebalanceApplyTopic(
 		AutoContinueRebalance:      true,                      // to continue without prompts
 		RetentionDropStepDuration:  retentionDropStepDuration, // not needed for rebalance
 		SkipConfirm:                true,                      // to enforce action: rebalance
-		AllowSettingsDeletion:      false,                     // Irrelevant here
+		Destructive:                false,                     // Irrelevant here
 		SleepLoopDuration:          rebalanceConfig.sleepLoopDuration,
 		TopicConfig:                topicConfig,
 	}

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -37,7 +37,7 @@ type TopicApplierConfig struct {
 	RetentionDropStepDuration  time.Duration
 	SkipConfirm                bool
 	IgnoreFewerPartitionsError bool
-	AllowSettingsDeletion      bool
+	Destructive                bool
 	SleepLoopDuration          time.Duration
 	TopicConfig                config.TopicConfig
 }
@@ -425,7 +425,7 @@ func (t *TopicApplier) updateSettings(
 		}
 	}
 
-	if len(missingKeys) > 0 && t.config.AllowSettingsDeletion {
+	if len(missingKeys) > 0 && t.config.Destructive {
 		log.Infof(
 			"Found %d key(s) set in cluster but missing from config for deletion:\n%s",
 			len(missingKeys),
@@ -461,7 +461,7 @@ func (t *TopicApplier) updateSettings(
 		}
 	}
 
-	if len(missingKeys) > 0 && !t.config.AllowSettingsDeletion {
+	if len(missingKeys) > 0 && !t.config.Destructive {
 		log.Warnf(
 			"Found %d key(s) set in cluster but missing from config:\n%s\nThese will be left as-is.",
 			len(missingKeys),

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -80,6 +80,27 @@ func TestApplyBasicUpdates(t *testing.T) {
 	applier.topicConfig.Spec.ReplicationFactor = 3
 	err = applier.Apply(ctx)
 	require.NotNil(t, err)
+	applier.topicConfig.Spec.ReplicationFactor = 2
+
+	// Settings are not deleted if AllowSettingsDeletion is false. They are
+	// if it is true
+	delete(applier.topicConfig.Spec.Settings, "cleanup.policy")
+	err = applier.Apply(ctx)
+	require.NoError(t, err)
+	topicInfo, err = applier.adminClient.GetTopic(ctx, topicName, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "delete", topicInfo.Config["cleanup.policy"])
+
+	applier.config.AllowSettingsDeletion = true
+	err = applier.Apply(ctx)
+	require.NoError(t, err)
+	topicInfo, err = applier.adminClient.GetTopic(ctx, topicName, true)
+	require.NoError(t, err)
+
+	_, present := topicInfo.Config["cleanup.policy"]
+	assert.False(t, present)
+
 }
 
 func TestApplyPlacementUpdates(t *testing.T) {

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -82,7 +82,7 @@ func TestApplyBasicUpdates(t *testing.T) {
 	require.NotNil(t, err)
 	applier.topicConfig.Spec.ReplicationFactor = 2
 
-	// Settings are not deleted if AllowSettingsDeletion is false. They are
+	// Settings are not deleted if Destructive is false. They are
 	// if it is true
 	delete(applier.topicConfig.Spec.Settings, "cleanup.policy")
 	err = applier.Apply(ctx)
@@ -92,7 +92,7 @@ func TestApplyBasicUpdates(t *testing.T) {
 
 	assert.Equal(t, "delete", topicInfo.Config["cleanup.policy"])
 
-	applier.config.AllowSettingsDeletion = true
+	applier.config.Destructive = true
 	err = applier.Apply(ctx)
 	require.NoError(t, err)
 	topicInfo, err = applier.adminClient.GetTopic(ctx, topicName, true)

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -346,6 +346,22 @@ func (t TopicSettings) ToConfigEntries(keys []string) ([]kafka.ConfigEntry, erro
 	return entries, nil
 }
 
+// Produces a slice of kafka-go config entries with empty value. Thus used
+// for deletion of the setting.
+func (t TopicSettings) ToEmptyConfigEntries(keys []string) []kafka.ConfigEntry {
+	entries := []kafka.ConfigEntry{}
+
+	if keys != nil {
+		for _, key := range keys {
+			entries = append(
+				entries,
+				kafka.ConfigEntry{ConfigName: key, ConfigValue: ""},
+			)
+		}
+	}
+	return entries
+}
+
 // HasKey returns whether the current settings instance contains the argument key.
 func (t TopicSettings) HasKey(key string) bool {
 	_, ok := t[key]


### PR DESCRIPTION
Related with issue https://github.com/segmentio/topicctl/issues/197.

The idea of this PR is to make topic apply a bit more declarative by supporting deletion of settings that are not present in config. 
As this could be a calamity if done by mistake, the behavior is disabled by default. A CLI argument `--destructive` is supported in the apply subcommand. If that flag is not set, the behavior is the same as it was before.

Example:
```
topicctl % ./build/topicctl apply --destructive  examples/local-cluster/topics/topic-default.yaml
{{topic-default local-cluster local-region local-env Topic that uses default (any) strategy for assigning partition brokers.
 map[] []} {3 2 0 map[cleanup.policy:delete max.message.bytes:5.54288e+06 message.timestamp.type:LogAppendTime] {in-rack  [] []} <nil>}}
[2024-06-07 16:53:35]  INFO Processing topic topic-default in config examples/local-cluster/topics/topic-default.yaml with cluster config /Users/filippopacifici/code/topicctl/examples/local-cluster/cluster.yaml
[2024-06-07 16:53:35]  INFO Starting apply for topic topic-default in environment local-env, cluster local-cluster
[2024-06-07 16:53:35]  INFO Validating configs...
[2024-06-07 16:53:35]  INFO Checking if topic already exists...
[2024-06-07 16:53:35]  INFO Updating existing topic 'topic-default'
[2024-06-07 16:53:35]  INFO Checking the existing state of the cluster, topic, and throttles...
[2024-06-07 16:53:35]  INFO All replicas are in-sync
[2024-06-07 16:53:35]  INFO Checking topic config settings...
[2024-06-07 16:53:35]  INFO Found 1 key(s) with different values:
-------------------------+----------------------+---------------------
           KEY           | CLUSTER VALUE (CURR) | CONFIG VALUE (NEW)  
-------------------------+----------------------+---------------------
  message.timestamp.type |                      | LogAppendTime       
-------------------------+----------------------+---------------------
[2024-06-07 16:53:35]  INFO Found 1 key(s) set in cluster but missing from config for deletion:
---------------+--------------------
      KEY      |   CLUSTER VALUE    
---------------+--------------------
  retention.ms | 6000000 (100 min)  
---------------+--------------------
OK to update to the new values in the topic config? (yes/no) 
```
Typing `yes` the retetion.ms setting is deleted.
If I run the command again there is no more diff to apply.

Test plan:
- See the example above
- Added a unit test as well