### PR TITLE
feat(notifier): add PoC JSON output option for topicctl diff

### DIFF
--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -282,7 +282,10 @@ func applyTopic(
 		allChanges = util.MergeMaps(allChanges, changes)
 	}
 
-	util.PrintChangesMap(allChanges)
+	if applyConfig.jsonOutput {
+		util.PrintChangesMap(allChanges)
+	}
+
 	return nil
 }
 

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -248,8 +248,8 @@ func applyTopic(
 	cliRunner := cli.NewCLIRunner(adminClient, log.Infof, false)
 
 	// initialize changesMap and add dry run flag
-	changesMap := make(map[string]interface{})
-	changesMap["_dryRun"] = applyConfig.dryRun
+	allChanges := make(map[string]interface{})
+	allChanges["dryRun"] = applyConfig.dryRun
 
 	for _, topicConfig := range topicConfigs {
 		topicConfig.SetDefaults()
@@ -279,9 +279,10 @@ func applyTopic(
 		if err != nil {
 			return err
 		}
-		util.PrintChangesMap(changes)
+		allChanges = util.MergeMaps(allChanges, changes)
 	}
 
+	util.PrintChangesMap(allChanges)
 	return nil
 }
 

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -312,7 +312,8 @@ func rebalanceApplyTopic(
 	}
 
 	cliRunner := cli.NewCLIRunner(adminClient, log.Infof, false)
-	if err := cliRunner.ApplyTopic(ctx, applierConfig); err != nil {
+	// TODO: add changes map from rebalancing
+	if _, err := cliRunner.ApplyTopic(ctx, applierConfig); err != nil {
 		return err
 	}
 

--- a/examples/local-cluster/topics/topic-default.yaml
+++ b/examples/local-cluster/topics/topic-default.yaml
@@ -9,7 +9,7 @@ meta:
 spec:
   partitions: 3
   replicationFactor: 1
-  retentionMinutes: 100
+  retentionMinutes: 102
   placement:
     strategy: in-rack
   settings:
@@ -23,7 +23,7 @@ meta:
   region: local-region
 spec:
   partitions: 16
-  retentionMinutes: 10081
+  retentionMinutes: 10080
   replicationFactor: 1
   placement:
     strategy: any
@@ -40,12 +40,12 @@ meta:
   region: local-region
 spec:
   partitions: 16
-  retentionMinutes: 10081
+  retentionMinutes: 10080
   replicationFactor: 1
   placement:
     strategy: any
   settings: {
-    'segment.bytes': 573741823, 
+    'segment.bytes': 573741829, 
     'compression.type': 'lz4',
     'message.timestamp.type': 'LogAppendTime'
   }

--- a/examples/local-cluster/topics/topic-default.yaml
+++ b/examples/local-cluster/topics/topic-default.yaml
@@ -1,5 +1,5 @@
 meta:
-  name: topic-default
+  name: test_topic_3
   cluster: local-cluster
   environment: local-env
   region: local-region
@@ -8,10 +8,44 @@ meta:
 
 spec:
   partitions: 3
-  replicationFactor: 2
+  replicationFactor: 1
   retentionMinutes: 100
   placement:
     strategy: in-rack
   settings:
     cleanup.policy: delete
     max.message.bytes: 5542880
+---
+meta:
+  name: test_topic_1
+  cluster: local-cluster
+  environment: local-env
+  region: local-region
+spec:
+  partitions: 16
+  retentionMinutes: 10081
+  replicationFactor: 1
+  placement:
+    strategy: any
+  settings: {
+    'segment.bytes': 573741823, 
+    'compression.type': 'lz4',
+    'message.timestamp.type': 'LogAppendTime'
+  }
+---
+meta:
+  name: test_topic_2
+  cluster: local-cluster
+  environment: local-env
+  region: local-region
+spec:
+  partitions: 16
+  retentionMinutes: 10081
+  replicationFactor: 1
+  placement:
+    strategy: any
+  settings: {
+    'segment.bytes': 573741823, 
+    'compression.type': 'lz4',
+    'message.timestamp.type': 'LogAppendTime'
+  }

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -156,13 +156,13 @@ func (t *TopicApplier) applyNewTopic(ctx context.Context) (map[string]interface{
 	if err != nil {
 		return nil, err
 	}
-	changes := make(map[string]interface{})
 
 	if t.config.DryRun {
 		log.Infof("Would create topic with config %+v", newTopicConfig)
-		// add newly created topic to changesMap json object
-		changes[t.topicConfig.Meta.Name] = newTopicConfig
-		changes[t.topicConfig.Meta.Name].(map[string]interface{})["action"] = "create"
+		changes, err := util.ProcessTopicConfigIntoMap(t.topicConfig.Meta.Name, newTopicConfig)
+		if err != nil {
+			return nil, err
+		}
 		return changes, nil
 	}
 
@@ -200,8 +200,10 @@ func (t *TopicApplier) applyNewTopic(ctx context.Context) (map[string]interface{
 	}
 
 	// add new topic config to changes map
-	changes[t.topicConfig.Meta.Name] = newTopicConfig
-	changes[t.topicConfig.Meta.Name].(map[string]interface{})["action"] = "create"
+	changes, err := util.ProcessTopicConfigIntoMap(t.topicConfig.Meta.Name, newTopicConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	return changes, nil
 }
@@ -212,7 +214,7 @@ func (t *TopicApplier) applyExistingTopic(
 ) (map[string]interface{}, error) {
 	log.Infof("Updating existing topic '%s'", t.topicName)
 	// TODO: applyExistingTopic changes
-	// changes := make(map[string]interface{})
+	// changes := make(map[string]map[string]interface{})
 
 	if err := t.checkExistingState(ctx, topicInfo); err != nil {
 		return nil, err

--- a/pkg/apply/format.go
+++ b/pkg/apply/format.go
@@ -190,13 +190,3 @@ func timeSuffix(msStr string) string {
 
 	return fmt.Sprintf(" (%d min)", msInt/60000)
 }
-
-// prints map of changes being made to stdout
-func PrintChangesMap(changesMap map[string]interface{}) error {
-	jsonChanges, err := json.Marshal(changesMap)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Map of changes: %s\n", jsonChanges)
-	return nil
-}

--- a/pkg/apply/format.go
+++ b/pkg/apply/format.go
@@ -93,13 +93,15 @@ func FormatSettingsDiff(
 	return string(bytes.TrimRight(buf.Bytes(), "\n")), nil
 }
 
-// FormatSettingsDiffJson formats the settings diffs as a JSON object instead of a table
-func FormatSettingsDiffJson(
+// FormatSettingsDiffMap formats the settings diffs as a map object instead of a table
+func FormatSettingsDiffMap(
+	topicName string,
 	topicSettings config.TopicSettings,
 	configMap map[string]string,
 	diffKeys []string,
-) ([]byte, error) {
-	diffsMap := make(map[string]map[string]interface{})
+) (map[string]interface{}, error) {
+	diffsMap := make(map[string]interface{})
+	diffsMap[topicName] = make(map[string]interface{})
 
 	for _, diffKey := range diffKeys {
 		configValueStr := configMap[diffKey]
@@ -110,15 +112,17 @@ func FormatSettingsDiffJson(
 		if topicSettings.HasKey(diffKey) {
 			valueStr, err = topicSettings.GetValueStr(diffKey)
 			if err != nil {
-				return []byte{}, err
+				return nil, err
 			}
 		}
 
-		diffsMap[diffKey] = make(map[string]interface{})
-		diffsMap[diffKey]["current"] = configValueStr
-		diffsMap[diffKey]["updated"] = valueStr
+		diffsMap[topicName].(map[string]interface{})["Action"] = "update"
+		diffsMap[topicName].(map[string]interface{})[diffKey] = map[string]interface{}{
+			"current": configValueStr,
+			"updated": valueStr,
+		}
 	}
-	return json.Marshal(diffsMap)
+	return diffsMap, nil
 }
 
 // FormatMissingKeys generates a table that summarizes the key/value pairs

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -111,14 +111,14 @@ func (c *CLIRunner) GetClusterID(ctx context.Context, full bool) error {
 func (c *CLIRunner) ApplyTopic(
 	ctx context.Context,
 	applierConfig apply.TopicApplierConfig,
-) error {
+) (map[string]interface{}, error) {
 	applier, err := apply.NewTopicApplier(
 		ctx,
 		c.adminClient,
 		applierConfig,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	highlighter := color.New(color.FgYellow, color.Bold).SprintfFunc()
@@ -130,13 +130,13 @@ func (c *CLIRunner) ApplyTopic(
 		highlighter(applierConfig.TopicConfig.Meta.Cluster),
 	)
 
-	err = applier.Apply(ctx)
+	changes, err := applier.Apply(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	c.printer("Apply completed successfully!")
-	return nil
+	return changes, nil
 }
 
 // CreateACL does an apply run according to the spec in the argument config.

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
+	log "github.com/sirupsen/logrus"
 )
 
 var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
@@ -83,7 +83,7 @@ func LoadTopicsFile(path string) ([]TopicConfig, error) {
 func LoadTopicBytes(contents []byte) (TopicConfig, error) {
 	config := TopicConfig{}
 	err := unmarshalYAMLStrict(contents, &config)
-	fmt.Println(config)
+	log.Infof("Loading config %+v", config)
 	return config, err
 }
 

--- a/pkg/util/confirm.go
+++ b/pkg/util/confirm.go
@@ -10,11 +10,12 @@ import (
 // Confirm shows the argument prompt to the user and returns a boolean based on whether or not
 // the user confirms that it's ok to continue.
 func Confirm(prompt string, skip bool) (bool, error) {
-	fmt.Printf("%s (yes/no) ", prompt)
 
 	if skip {
 		log.Infof("Automatically answering yes because skip is set to true")
 		return true, nil
+	} else {
+		fmt.Printf("%s (yes/no) ", prompt)
 	}
 
 	var response string

--- a/pkg/util/maps.go
+++ b/pkg/util/maps.go
@@ -84,7 +84,7 @@ func PrintChangesMap(changesMap map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Map of changes: %s\n", jsonChanges)
+	fmt.Printf("%s\n", jsonChanges)
 	return nil
 }
 

--- a/pkg/util/maps.go
+++ b/pkg/util/maps.go
@@ -88,7 +88,7 @@ func PrintChangesMap(changesMap map[string]interface{}) error {
 	return nil
 }
 
-// processes TopicConfig into changes map
+// processes TopicConfig object into a map
 func ProcessTopicConfigIntoMap(topicName string, topicConfig kafka.TopicConfig) (map[string]interface{}, error) {
 	changes := make(map[string]interface{})
 	// add newly created topic to changes json object

--- a/pkg/util/maps.go
+++ b/pkg/util/maps.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"encoding/json"
+	"fmt"
 	"hash/fnv"
 	"math/rand"
 	"sort"
@@ -64,4 +66,21 @@ func SortedKeysByValue(input map[int]int, asc bool, keySorter KeySorter) []int {
 	}
 
 	return keys
+}
+
+func MergeMaps(a map[string]interface{}, b map[string]interface{}) map[string]interface{} {
+	for k, v := range b {
+		a[k] = v
+	}
+	return a
+}
+
+// prints map of changes being made to stdout
+func PrintChangesMap(changesMap map[string]interface{}) error {
+	jsonChanges, err := json.Marshal(changesMap)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Map of changes: %s\n", jsonChanges)
+	return nil
 }


### PR DESCRIPTION
## Description
This adds the `--json-output` flag to topicctl, which prints a json blob of changes maded during a `topicctl apply` to stdout at the end of an apply run. Currently this only works for creating a topic and updating that topic's settings.

Right now the flag only controls whether the json blob is printed, all of the logic for producing the json blob still happens in the backend regardless of whether the flag is passed or not. This can be improved in the future.

## Running this yourself
To test this for yourself, checkout the branch, run `make install` in repo root, edit the topics in `topic-default.yaml`, and run:
```bash
topicctl apply examples/local-cluster/topics/topic-default.yaml  --json-output --dry-run
```
Make sure you have a kafka container running (you can get one by running `sentry devservices up` in the sentry repo).

## Sample Output
- creating 3 new topics:
```
{"dryRun":true,"test_topic_1":{"Action":"create","ConfigEntries":[{"ConfigName":"compression.type","ConfigValue":"lz4"},{"ConfigName":"message.timestamp.type","ConfigValue":"LogAppendTime"},{"ConfigName":"segment.bytes","ConfigValue":"573741823"},{"ConfigName":"retention.ms","ConfigValue":"604800000"}],"NumPartitions":16,"ReplicaAssignments":null,"ReplicationFactor":1,"Topic":"test_topic_1"},"test_topic_2":{"Action":"create","ConfigEntries":[{"ConfigName":"compression.type","ConfigValue":"lz4"},{"ConfigName":"message.timestamp.type","ConfigValue":"LogAppendTime"},{"ConfigName":"segment.bytes","ConfigValue":"573741829"},{"ConfigName":"retention.ms","ConfigValue":"604800000"}],"NumPartitions":16,"ReplicaAssignments":null,"ReplicationFactor":1,"Topic":"test_topic_2"},"test_topic_3":{"Action":"create","ConfigEntries":[{"ConfigName":"cleanup.policy","ConfigValue":"delete"},{"ConfigName":"max.message.bytes","ConfigValue":"5542880"},{"ConfigName":"retention.ms","ConfigValue":"6120000"}],"NumPartitions":3,"ReplicaAssignments":null,"ReplicationFactor":1,"Topic":"test_topic_3"}}
```
- updating 3 topics:
```
{"dryRun":true,"test_topic_1":{"Action":"update","retention.ms":{"current":"604860000","updated":"604800000"}},"test_topic_2":{"Action":"update","retention.ms":{"current":"604860000","updated":"604800000"},"segment.bytes":{"current":"573741823","updated":"573741829"}},"test_topic_3":{"Action":"update","retention.ms":{"current":"6000000","updated":"6120000"}}}
```
- creating 1 topic, updating 2:
```
{"dryRun":true,"test_topic_1":{"Action":"create","ConfigEntries":[{"ConfigName":"compression.type","ConfigValue":"lz4"},{"ConfigName":"message.timestamp.type","ConfigValue":"LogAppendTime"},{"ConfigName":"segment.bytes","ConfigValue":"573741823"},{"ConfigName":"retention.ms","ConfigValue":"604800000"}],"NumPartitions":16,"ReplicaAssignments":null,"ReplicationFactor":1,"Topic":"test_topic_1"},"test_topic_2":{"Action":"update","retention.ms":{"current":"604800000","updated":"605400000"},"segment.bytes":{"current":"573741829","updated":"573741830"}},"test_topic_3":{"Action":"update","retention.ms":{"current":"6120000","updated":"6720000"}}}
```