### PR TITLE
Remove test010 from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,109 +27,6 @@ jobs:
         echo github.ref_type=${{ github.ref_type }}
         echo release-ref=${{ steps.regex-match.outputs.match }}
 
-  test010:
-    runs-on: ubuntu-latest
-    container:
-      image: cimg/go:1.19
-      env:
-        GO111MODULE: "on"
-        KAFKA_TOPICS_TEST_ZK_ADDR: zookeeper:2181
-        KAFKA_TOPICS_TEST_KAFKA_ADDR: kafka1:9092
-    steps:
-    - name: Check out repository code 
-      uses: actions/checkout@v3
-    - name: Go setup
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.19
-    - name: Display Go version
-      run: go version
-    - name: Run tests
-      run: make test
-      env:
-        KAFKA_TOPICS_TEST_ZK_ADDR: zookeeper:2181
-        KAFKA_TOPICS_TEST_KAFKA_ADDR: kafka1:9092
-
-    services:
-      zookeeper:
-        image: bitnami/zookeeper:latest
-        ports:
-          - "2181:2181"
-        env:
-          ALLOW_ANONYMOUS_LOGIN: yes
-
-      kafka1:
-        image: bitnami/kafka:0.10.2.1
-        ports:
-          - "9092:9092"
-        env:
-          KAFKA_BROKER_ID: 1
-          KAFKA_BROKER_RACK: zone1
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_ADVERTISED_HOST_NAME: kafka1
-          KAFKA_ADVERTISED_PORT: 9092
-
-      kafka2:
-        image: bitnami/kafka:0.10.2.1
-        ports:
-          - "9093:9092"
-        env:
-          KAFKA_BROKER_ID: 2
-          KAFKA_BROKER_RACK: zone1
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_ADVERTISED_HOST_NAME: kafka2
-          KAFKA_ADVERTISED_PORT: 9092
-
-      kafka3:
-        image: bitnami/kafka:0.10.2.1
-        ports:
-          - "9094:9092"
-        env:
-          KAFKA_BROKER_ID: 3
-          KAFKA_BROKER_RACK: zone2
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_ADVERTISED_HOST_NAME: kafka3
-          KAFKA_ADVERTISED_PORT: 9092
-
-      kafka4:
-        image: bitnami/kafka:0.10.2.1
-        ports:
-          - "9095:9092"
-        env:
-          KAFKA_BROKER_ID: 4
-          KAFKA_BROKER_RACK: zone2
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_ADVERTISED_HOST_NAME: kafka4
-          KAFKA_ADVERTISED_PORT: 9092
-
-      kafka5:
-        image: bitnami/kafka:0.10.2.1
-        ports:
-          - "9096:9092"
-        env:
-          KAFKA_BROKER_ID: 5
-          KAFKA_BROKER_RACK: zone3
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_ADVERTISED_HOST_NAME: kafka5
-          KAFKA_ADVERTISED_PORT: 9092
-
-      kafka6:
-        image: bitnami/kafka:0.10.2.1
-        ports:
-          - "9097:9092"
-        env:
-          KAFKA_BROKER_ID: 6
-          KAFKA_BROKER_RACK: zone3
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_ADVERTISED_HOST_NAME: kafka6
-          KAFKA_ADVERTISED_PORT: 9092
-
 
   test270:
     runs-on: ubuntu-latest
@@ -364,7 +261,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
   publish-ghcr:
-    needs: [setup, test010, test270, test360]
+    needs: [setup, test270, test360]
     runs-on: ubuntu-latest
     if: ${{ ( github.ref_type == 'branch' ) && (( github.ref_name == 'master' ) || ( github.ref_name == 'v0' )) }}
     steps:
@@ -406,7 +303,7 @@ jobs:
     - run: echo "GHCR PUBLISH SUCCESSFUL"
 
   publish-dockerhub:
-    needs: [setup, test010, test270, test360]
+    needs: [setup, test270, test360]
     environment: CICD
     env: 
       RELEASE_TAG: ${{ needs.setup.outputs.version-tag }}


### PR DESCRIPTION
This docker image is no longer supported and we need to remove it from CI to get CI to work again

> [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/bitnami/kafka:0.10.2.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
  Warning: Docker pull failed with exit code 1, back off 2.816 seconds before retry.