### PR TITLE
Ssingudasu/bug fix conn timeout flag

### DIFF
--- a/cmd/topicctl/subcmd/shared.go
+++ b/cmd/topicctl/subcmd/shared.go
@@ -125,6 +125,7 @@ func (s sharedOptions) getAdminClient(
 				UsernameOverride:          s.saslUsername,
 				PasswordOverride:          s.saslPassword,
 				SecretsManagerArnOverride: s.saslSecretsManagerArn,
+				KafkaConnTimeout:          s.connTimeout,
 			},
 		)
 	} else if s.brokerAddr != "" {

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -203,6 +203,7 @@ type AdminClientOpts struct {
 	UsernameOverride          string
 	PasswordOverride          string
 	SecretsManagerArnOverride string
+	KafkaConnTimeout          time.Duration
 }
 
 // NewAdminClient returns a new admin client using the parameters in the current cluster config.
@@ -268,6 +269,7 @@ func (c ClusterConfig) NewAdminClient(
 						Password:          saslPassword,
 						SecretsManagerArn: secretsManagerArn,
 					},
+					ConnTimeout: opts.KafkaConnTimeout,
 				},
 				ExpectedClusterID: c.Spec.ClusterID,
 				ReadOnly:          opts.ReadOnly,
@@ -284,6 +286,7 @@ func (c ClusterConfig) NewAdminClient(
 				ExpectedClusterID: c.Spec.ClusterID,
 				Sess:              sess,
 				ReadOnly:          opts.ReadOnly,
+				KafkaConnTimeout:  opts.KafkaConnTimeout,
 			},
 		)
 	}


### PR DESCRIPTION
# Description:

This PR is a bug fix to honor kafka `--conn-timeout` flag when `--cluster-config` is provided