### PR TITLE
Optional flag to enable logging in json format

### DIFF
--- a/cmd/topicctl/subcmd/root.go
+++ b/cmd/topicctl/subcmd/root.go
@@ -12,6 +12,7 @@ import (
 
 var debug bool
 var noSpinner bool
+var jsonOutput bool
 
 // RootCmd is the cobra CLI root command.
 var RootCmd = &cobra.Command{
@@ -40,6 +41,12 @@ func init() {
 		false,
 		"disable all UI spinners",
 	)
+	RootCmd.PersistentFlags().BoolVar(
+		&jsonOutput,
+		"json-output",
+		false,
+		"enable logging in json format",
+	)
 }
 
 // Execute runs topicctl.
@@ -55,6 +62,9 @@ func Execute(versionRef string) {
 func preRun(cmd *cobra.Command, args []string) error {
 	if debug {
 		log.SetLevel(log.DebugLevel)
+	}
+	if jsonOutput{
+		log.SetFormatter(&log.JSONFormatter{})
 	}
 	return nil
 }


### PR DESCRIPTION
This change introduces a new global flag `--json-output` which when provided generates logs in JSON format. This is very helpful especially when the logs are parsed. Datadog in our case. By default, all the logs generated by Topicctl are currently flagged as errors(see attached). I'm sure there are more use cases that would get benefitted by logs in json format.

![image](https://github.com/segmentio/topicctl/assets/80044587/7cd529d3-b1c1-4dcb-946c-b0abd6e3ddd1)

With Json logging enabled:

```json 
{"msg":"Partition placement already satisfies strategy 'any'","level":"info","time":"2024-06-26T12:42:46Z"}
{"msg":"Checking partition placement...","level":"info","time":"2024-06-26T12:42:46Z"}
```

![image](https://github.com/segmentio/topicctl/assets/80044587/ac728b08-6009-40ac-9579-8a2e86748568)
