### PR TITLE
docker-compose.yml: specify AMD64 platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,17 +9,26 @@ services:
     hostname: zookeeper
     image: bitnami/zookeeper:latest
     ports:
-      - "2181:2181"
+    - "2181:2181"
     environment:
       ALLOW_ANONYMOUS_LOGIN: yes
 
   # Zone 1 brokers
+    # If you are on arm64 and experiencing issues with the tests (hangs,
+    # connection reset) then try the following in order:
+
+    # - stopping and removing all downloaded container images
+    # - ensuring you have the latest Docker Desktop version
+    # - factory reset your Docker Desktop settings
+
+    # If you are still running into issues please post in #help-infra-seg.
+    platform: linux/amd64
   kafka1:
     container_name: kafka1
     hostname: 169.254.123.123
     image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
-      - "9092:9092"
+    - "9092:9092"
     environment:
       KAFKA_CFG_BROKER_ID: 1
       KAFKA_CFG_BROKER_RACK: zone1
@@ -30,14 +39,16 @@ services:
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://169.254.123.123:9092
     restart: on-failure
     depends_on:
-      - zookeeper
+    - zookeeper
 
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   kafka2:
     container_name: kafka2
     hostname: 169.254.123.123
     image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
-      - "9093:9092"
+    - "9093:9092"
     environment:
       KAFKA_CFG_BROKER_ID: 2
       KAFKA_CFG_BROKER_RACK: zone1
@@ -48,15 +59,17 @@ services:
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://169.254.123.123:9093
     restart: on-failure
     depends_on:
-      - zookeeper
+    - zookeeper
 
   # Zone 2 brokers
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   kafka3:
     container_name: kafka3
     hostname: 169.254.123.123
     image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
-      - "9094:9092"
+    - "9094:9092"
     environment:
       KAFKA_CFG_BROKER_ID: 3
       KAFKA_CFG_BROKER_RACK: zone2
@@ -67,14 +80,16 @@ services:
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://169.254.123.123:9094
     restart: on-failure
     depends_on:
-      - zookeeper
+    - zookeeper
 
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   kafka4:
     container_name: kafka4
     hostname: 169.254.123.123
     image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
-      - "9095:9092"
+    - "9095:9092"
     environment:
       KAFKA_CFG_BROKER_ID: 4
       KAFKA_CFG_BROKER_RACK: zone2
@@ -85,15 +100,17 @@ services:
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://169.254.123.123:9095
     restart: on-failure
     depends_on:
-      - zookeeper
+    - zookeeper
 
   # Zone 3 brokers
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   kafka5:
     container_name: kafka5
     hostname: 169.254.123.123
     image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
-      - "9096:9092"
+    - "9096:9092"
     environment:
       KAFKA_CFG_BROKER_ID: 5
       KAFKA_CFG_BROKER_RACK: zone3
@@ -104,14 +121,16 @@ services:
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://169.254.123.123:9096
     restart: on-failure
     depends_on:
-      - zookeeper
+    - zookeeper
 
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   kafka6:
     container_name: kafka6
     hostname: 169.254.123.123
     image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
-      - "9097:9092"
+    - "9097:9092"
     environment:
       KAFKA_CFG_BROKER_ID: 6
       KAFKA_CFG_BROKER_RACK: zone3
@@ -122,4 +141,6 @@ services:
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://169.254.123.123:9097
     restart: on-failure
     depends_on:
-      - zookeeper
+    - zookeeper
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64


### PR DESCRIPTION
Several Docker images used by Segment do not work reliably on Mac M1 laptops,
which use the arm64 chipset. Commonly, these are images that were built several
years ago, before M1 laptops were in widespread use, and behave unpredictably
when run on an arm64 chipset.

The simplest workaround is to ensure that the Docker environment is always
running on amd64. If this service runs on Graviton instances (which use the
arm64 chipset), then you should close this PR, or reverse the "platform" to
instead specify "linux/arm64".

This change should ensure that employees with Apple M1 laptops will be able to
reliably start and run Docker containers on this repository.

This commit may include some whitespace-only changes, which are an
artifact of the comment-preserving YAML parser that was used to modify the
docker-compose.yml file. To exclude these from the diff, append ?w=1 to the pull
request URL.

This pull request was generated by a script run by Kevin Burke. There are over
300 docker-compose files at Segment and he would appreciate your help testing
and merging this pull request. At this scale, it is not possible to satisfy
every repository's rules for formatting, labeling, and testing pull requests.

If you have questions, please post in #help-infra-seg.
JIRA: https://segment.atlassian.net/browse/IO-2101
