### PR TITLE
fix: check if Secrets Manager ARN is valid

### DIFF
--- a/pkg/admin/connector.go
+++ b/pkg/admin/connector.go
@@ -224,9 +224,13 @@ func GetKafkaCredentials(svc secretsmanageriface.SecretsManagerAPI, secretArn st
 	log.Debugf("Fetching credentials from Secrets Manager for secret: %s", secretArn)
 	var creds credentials
 
+	if !arn.IsARN(secretArn) {
+		return creds, fmt.Errorf("invalid ARN provided: %s", secretArn)
+	}
+
 	arn, err := arn.Parse(secretArn)
 	if err != nil {
-		return creds, fmt.Errorf("Couldn't parse the ARN for secret: %s, error: %v", secretArn, err)
+		return creds, fmt.Errorf("couldn't parse the ARN for secret: %s, error: %v", secretArn, err)
 	}
 	// Remove "secret:" from the resource to get the secret name
 	secretName := strings.Split(arn.Resource, ":")[1]

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current topicctl version.
-const Version = "1.18.0"
+const Version = "1.18.1"


### PR DESCRIPTION
Avoid panic when invalid arn is specified