### PR TITLE
[DP-2568] - topiccctl keystore bug fix for docker-compose-auth

### DIFF
--- a/docker-compose-auth.yml
+++ b/docker-compose-auth.yml
@@ -48,7 +48,7 @@ services:
 
       KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
 
-      KAFKA_CFG_SSL_KEYSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.truststore.jks
+      KAFKA_CFG_SSL_KEYSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.keystore.jks
       KAFKA_CFG_SSL_KEYSTORE_PASSWORD: test123
 
       KAFKA_CFG_SSL_TRUSTSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.truststore.jks


### PR DESCRIPTION
# Description
docker-compose-auth KAFKA_CFG_SSL_KEYSTORE_LOCATION has been configured incorrectly causing tls connections to fail(9093, 9095 ports)

This PR is a bug fix to change KAFKA_CFG_SSL_KEYSTORE_LOCATION to correct value kafka.keystore.jks

## Testing:
### Before fix:
```
STEP-1: Spin up docker-compose
$ docker-compose -f ./docker-compose-auth.yml up -d

STEP-2: Build topicctl
$ go build -o ./build/topicctl -a ./cmd/topicctl

STEP-3: Connect to cluster via auth (brokerAddr: localhost:9095)
$ ./build/topicctl get topics --cluster-config examples/auth/cluster.yaml
[2024-12-06 12:21:37] ERROR tls: first record does not look like a TLS handshake
```

### After fix:
```
STEP-1: Spin up docker-compose
$ docker-compose -f ./docker-compose-auth.yml up -d

STEP-2: Build topicctl
$ go build -o ./build/topicctl -a ./cmd/topicctl

STEP-3: Connect to cluster via auth (brokerAddr: localhost:9095)
$ ./build/topicctl get topics --cluster-config examples/auth/cluster.yaml
[2024-12-06 12:25:47]  INFO Topics:
-------+------------+-------------+-----------+------------
  NAME | PARTITIONS | REPLICATION | RETENTION |   RACKS
       |            |             |   MINS    | (MIN,MAX)
-------+------------+-------------+-----------+------------
-------+------------+-------------+-----------+------------
```