### PR TITLE
add support for throttle wildcard in settings

### DIFF
--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -62,6 +62,9 @@ var keyValidators = map[string]configValidator{
 		return intVal >= 0
 	},
 	"follower.replication.throttled.replicas": func(v string) bool {
+		if v == "*" {
+			return true
+		}
 		subValues := strings.Split(v, ",")
 		for _, subValue := range subValues {
 			elements := strings.Split(subValue, ":")
@@ -86,6 +89,9 @@ var keyValidators = map[string]configValidator{
 		return intVal >= 0
 	},
 	"leader.replication.throttled.replicas": func(v string) bool {
+		if v == "*" {
+			return true
+		}
 		subValues := strings.Split(v, ",")
 		for _, subValue := range subValues {
 			elements := strings.Split(subValue, ":")

--- a/pkg/config/settings_test.go
+++ b/pkg/config/settings_test.go
@@ -58,6 +58,14 @@ func TestValidateSettings(t *testing.T) {
 			expError: false,
 		},
 		{
+			description: "wildcard throttle",
+			settings: TopicSettings{
+				"follower.replication.throttled.replicas": "*",
+				"leader.replication.throttled.replicas":   "*",
+			},
+			expError: false,
+		},
+		{
 			description: "unrecognized key",
 			settings: TopicSettings{
 				"bad-key": "1",


### PR DESCRIPTION
docs:

> alternatively the wildcard '*' can be used to throttle all replicas for this topic.

This adds support for that for

- [leader.replication.throttled.replicas](https://kafka.apache.org/documentation/#topicconfigs_leader.replication.throttled.replicas)
- [follower.replication.throttled.replicas](https://kafka.apache.org/documentation/#topicconfigs_follower.replication.throttled.replicas)