### PR TITLE
delete consumer group

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -648,6 +648,19 @@ func (c *CLIRunner) ResetOffsets(
 	return nil
 }
 
+// DeleteGroup deletes a single consumer group.
+func (c *CLIRunner) DeleteGroup(ctx context.Context, groupID string) error {
+	c.startSpinner()
+	err := groups.Delete(ctx, c.adminClient.GetConnector(), groupID)
+	c.stopSpinner()
+	if err != nil {
+		return err
+	}
+
+	c.printer("Success")
+	return nil
+}
+
 // Tail prints out a stream of the latest messages in a topic.
 func (c *CLIRunner) Tail(
 	ctx context.Context,


### PR DESCRIPTION
Add a command to delete a consumer group. This is useful to remove a consumer group that has stopped consuming. Check that the consumer group exists and is not dead, and if so, remove it directly.

This is a _little_ unsafe, as we simply remove the group without asking for confirmation. I suppose we could do so, but it seems a little gratuitous. 