### PR TITLE
fix: allow expanding cross-rack topics

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -548,7 +548,7 @@ func (t *TopicApplier) updatePartitionsHelper(
 			true,
 			picker,
 		)
-	case config.PlacementStrategyBalancedLeaders, config.PlacementStrategyAny:
+	case config.PlacementStrategyBalancedLeaders, config.PlacementStrategyAny, config.PlacementStrategyCrossRack:
 		extender = extenders.NewBalancedExtender(
 			t.brokers,
 			false,


### PR DESCRIPTION
[We already test for this](https://github.com/segmentio/topicctl/blob/3a2269ff468e198617a40b22d456deffc1809d04/pkg/apply/extenders/balanced_test.go#L12) so no additional testing should be needed. It seems like we simply forgot to update this switch statement way back when we added the cross-rack placement strategy