### PR TITLE
fix: add sasl-secrets-manager-arn to shared opts

### DIFF
--- a/cmd/topicctl/subcmd/shared.go
+++ b/cmd/topicctl/subcmd/shared.go
@@ -314,4 +314,10 @@ func addSharedConfigOnlyFlags(cmd *cobra.Command, options *sharedOptions) {
 		os.Getenv("TOPICCTL_SASL_USERNAME"),
 		"SASL username if using SASL; will override value set in cluster config",
 	)
+	cmd.PersistentFlags().StringVar(
+		&options.saslSecretsManagerArn,
+		"sasl-secrets-manager-arn",
+		os.Getenv("TOPICCTL_SASL_SECRETS_MANAGER_ARN"),
+		"Secrets Manager ARN to use for credentials if using SASL; will override value set in cluster config",
+	)
 }

--- a/cmd/topicctl/subcmd/shared.go
+++ b/cmd/topicctl/subcmd/shared.go
@@ -314,7 +314,7 @@ func addSharedConfigOnlyFlags(cmd *cobra.Command, options *sharedOptions) {
 		os.Getenv("TOPICCTL_SASL_USERNAME"),
 		"SASL username if using SASL; will override value set in cluster config",
 	)
-	cmd.PersistentFlags().StringVar(
+	cmd.Flags().StringVar(
 		&options.saslSecretsManagerArn,
 		"sasl-secrets-manager-arn",
 		os.Getenv("TOPICCTL_SASL_SECRETS_MANAGER_ARN"),


### PR DESCRIPTION
Several subcommands use a subset of the config options and sasl-secrets-manager was not included there. This should also fix https://github.com/segmentio/topicctl/issues/205