### PR TITLE
fix: honor sasl params at command line over config file

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current topicctl version.
-const Version = "1.19.1"
+const Version = "1.19.2"


### PR DESCRIPTION
Currently, if spec.sasl.secretsManagerArn is defined in a cluster configuration file, it will take precedence over values for sasl-username and sasl-password provided at the command line.

This is contrary to [conventional patterns of precedence](https://github.com/spf13/viper?tab=readme-ov-file#why-viper) where CLI options are highest, followed by env, file, and defaults. Furthermore, in certain contexts (eg tooling automation) it may not be feasible to change the given cluster configuration file, making it impossible to override to a different SASL credential.

This PR corrects this and when *overriding* configuration ("overriding", according to topicctl, occurs via CLI *or* env) for sasl-username and sasl-password, it ensures secretsManagerArn is not used (whether from config file or itself an override).