### PR TITLE
chore: bitnami -> bitnamilegacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,14 @@ jobs:
 
     services:
       zookeeper:
-        image: bitnami/zookeeper:latest
+        image: bitnamilegacy/zookeeper:latest
         ports:
           - "2181:2181"
         env:
           ALLOW_ANONYMOUS_LOGIN: yes
 
       kafka1:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9092:9092"
         env:
@@ -75,7 +75,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka2:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9093:9092"
         env:
@@ -89,7 +89,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka3:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9094:9092"
         env:
@@ -103,7 +103,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka4:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9095:9092"
         env:
@@ -117,7 +117,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka5:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9096:9092"
         env:
@@ -131,7 +131,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka6:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9097:9092"
         env:
@@ -170,14 +170,14 @@ jobs:
 
     services:
       zookeeper:
-        image: bitnami/zookeeper:latest
+        image: bitnamilegacy/zookeeper:latest
         ports:
           - "2181:2181"
         env:
           ALLOW_ANONYMOUS_LOGIN: yes
 
       kafka1:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9092:9092"
         env:
@@ -191,7 +191,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka2:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9093:9092"
         env:
@@ -205,7 +205,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka3:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9094:9092"
         env:
@@ -219,7 +219,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka4:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9095:9092"
         env:
@@ -233,7 +233,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka5:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9096:9092"
         env:
@@ -247,7 +247,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka6:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9097:9092"
         env:

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ make test
 
 You can change the Kafka version of the local cluster by setting the
 `KAFKA_IMAGE_TAG` environment variable when running `docker-compose up -d`. See the
-[`bitnami/kafka` dockerhub page](https://hub.docker.com/r/bitnami/kafka/tags) for more
+[`bitnamilegacy/kafka` dockerhub page](https://hub.docker.com/r/bitnamilegacy/kafka/tags) for more
 details on the available versions.
 
 #### Run against local cluster

--- a/docker-compose-auth.yml
+++ b/docker-compose-auth.yml
@@ -18,7 +18,7 @@ services:
   zookeeper:
     container_name: zookeeper
     hostname: zookeeper
-    image: bitnami/zookeeper:latest
+    image: bitnamilegacy/zookeeper:latest
     ports:
       - "2181:2181"
     environment:
@@ -27,7 +27,7 @@ services:
   kafka:
     container_name: kafka
     hostname: kafka
-    image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
+    image: bitnamilegacy/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     depends_on:
       - zookeeper
     restart: on-failure:3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 # By default, this docker-compose setup uses Kafka 2.7.0. This version can
 # be overwritten by setting the KAFKA_IMAGE_TAG environment variable.
 #
-# See https://hub.docker.com/r/bitnami/kafka/tags for the complete list.
+# See https://hub.docker.com/r/bitnamilegacy/kafka/tags for the complete list.
 version: '3'
 services:
   zookeeper:
     container_name: zookeeper
     hostname: zookeeper
-    image: bitnami/zookeeper:latest
+    image: bitnamilegacy/zookeeper:latest
     ports:
       - "2181:2181"
     environment:
@@ -17,7 +17,7 @@ services:
   kafka1:
     container_name: kafka1
     hostname: 169.254.123.123
-    image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
+    image: bitnamilegacy/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
       - "9092:9092"
     environment:
@@ -35,7 +35,7 @@ services:
   kafka2:
     container_name: kafka2
     hostname: 169.254.123.123
-    image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
+    image: bitnamilegacy/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
       - "9093:9092"
     environment:
@@ -54,7 +54,7 @@ services:
   kafka3:
     container_name: kafka3
     hostname: 169.254.123.123
-    image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
+    image: bitnamilegacy/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
       - "9094:9092"
     environment:
@@ -72,7 +72,7 @@ services:
   kafka4:
     container_name: kafka4
     hostname: 169.254.123.123
-    image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
+    image: bitnamilegacy/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
       - "9095:9092"
     environment:
@@ -91,7 +91,7 @@ services:
   kafka5:
     container_name: kafka5
     hostname: 169.254.123.123
-    image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
+    image: bitnamilegacy/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
       - "9096:9092"
     environment:
@@ -109,7 +109,7 @@ services:
   kafka6:
     container_name: kafka6
     hostname: 169.254.123.123
-    image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
+    image: bitnamilegacy/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     ports:
       - "9097:9092"
     environment:


### PR DESCRIPTION
The bitnami docker repository is being deprecated soon and image pulls will fail. Given we only use these "unhardened" images for local development and not production and the "hardened" versions do not support the versions of Kafka we use, the easiest thing for now is to change the repository to the bitnamilegacy one
https://github.com/bitnami/containers/issues/83267