### PR TITLE
Feature: Add create user command for SCRAM user management

### DIFF
--- a/examples/auth/users/user-default.yaml
+++ b/examples/auth/users/user-default.yaml
@@ -1,0 +1,11 @@
+meta:
+  name: test-user
+  cluster: auth-cluster
+  region: us-west-2
+  environment: dev
+  description: A sample SCRAM user for testing
+spec:
+  name: test-user
+  mechanism: scram-sha-256
+  password: "secure-password-123"
+  iterations: 4096

--- a/examples/auth/users/users-multi.yaml
+++ b/examples/auth/users/users-multi.yaml
@@ -1,0 +1,23 @@
+meta:
+  name: app-user
+  cluster: auth-cluster
+  region: us-west-2
+  environment: dev
+  description: Application service user
+spec:
+  name: app-user
+  mechanism: scram-sha-256
+  password: "app-secret-123"
+  iterations: 4096
+---
+meta:
+  name: admin-user
+  cluster: auth-cluster
+  region: us-west-2
+  environment: dev
+  description: Admin user with higher security
+spec:
+  name: admin-user
+  mechanism: scram-sha-512
+  password: "admin-secret-456"
+  iterations: 8192

--- a/pkg/config/user.go
+++ b/pkg/config/user.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/segmentio/kafka-go"
+)
+
+// UserConfig represents the configuration for a Kafka SCRAM user.
+type UserConfig struct {
+	Meta ResourceMeta `json:"meta"`
+	Spec UserSpec     `json:"spec"`
+}
+
+// UserSpec contains the specification for a Kafka SCRAM user.
+type UserSpec struct {
+	// Name is the username for the SCRAM user
+	Name string `json:"name"`
+
+	// Mechanism is the SCRAM mechanism (scram-sha-256 or scram-sha-512)
+	Mechanism string `json:"mechanism"`
+
+	// Password is the plain-text password that will be used to generate SCRAM credentials
+	Password string `json:"password"`
+
+	// Iterations is the number of iterations to use for SCRAM credential generation.
+	// If not specified, defaults to 4096.
+	Iterations int `json:"iterations,omitempty"`
+}
+
+// SetDefaults sets default values for the user configuration.
+func (u *UserConfig) SetDefaults() {
+	if u.Spec.Iterations == 0 {
+		u.Spec.Iterations = 4096
+	}
+	if u.Spec.Mechanism == "" {
+		u.Spec.Mechanism = "scram-sha-256"
+	}
+}
+
+// Validate evaluates whether the user config is valid.
+func (u *UserConfig) Validate() error {
+	var err error
+
+	// Validate metadata
+	if metaErr := u.Meta.Validate(); metaErr != nil {
+		err = multierror.Append(err, metaErr)
+	}
+
+	// Validate user spec
+	if u.Spec.Name == "" {
+		err = multierror.Append(err, errors.New("User name cannot be empty"))
+	}
+
+	if u.Spec.Password == "" {
+		err = multierror.Append(err, errors.New("User password cannot be empty"))
+	}
+
+	// Validate SCRAM mechanism
+	mechanism := strings.ToLower(strings.ReplaceAll(u.Spec.Mechanism, "_", "-"))
+	if mechanism != "scram-sha-256" && mechanism != "scram-sha-512" {
+		err = multierror.Append(
+			err,
+			errors.New("User mechanism must be either 'scram-sha-256' or 'scram-sha-512'"),
+		)
+	}
+
+	// Validate iterations
+	if u.Spec.Iterations < 1000 {
+		err = multierror.Append(
+			err,
+			errors.New("User iterations must be at least 1000 for security"),
+		)
+	}
+
+	return err
+}
+
+// ToScramMechanism converts the mechanism string to kafka-go ScramMechanism.
+func (u *UserConfig) ToScramMechanism() kafka.ScramMechanism {
+	mechanism := strings.ToLower(strings.ReplaceAll(u.Spec.Mechanism, "_", "-"))
+	switch mechanism {
+	case "scram-sha-256":
+		return kafka.ScramMechanismSha256
+	case "scram-sha-512":
+		return kafka.ScramMechanismSha512
+	default:
+		// Default to SHA-256 if unknown
+		return kafka.ScramMechanismSha256
+	}
+}

--- a/pkg/config/user_test.go
+++ b/pkg/config/user_test.go
@@ -1,0 +1,263 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserConfigValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		userConfig  UserConfig
+		shouldError bool
+		errorCount  int
+	}{
+		{
+			name: "valid user config with SHA256",
+			userConfig: UserConfig{
+				Meta: ResourceMeta{
+					Name:        "test-user",
+					Cluster:     "test-cluster",
+					Region:      "us-west-2",
+					Environment: "dev",
+				},
+				Spec: UserSpec{
+					Name:       "test-user",
+					Mechanism:  "scram-sha-256",
+					Password:   "secure-password-123",
+					Iterations: 4096,
+				},
+			},
+			shouldError: false,
+		},
+		{
+			name: "valid user config with SHA512",
+			userConfig: UserConfig{
+				Meta: ResourceMeta{
+					Name:        "test-user",
+					Cluster:     "test-cluster",
+					Region:      "us-west-2",
+					Environment: "dev",
+				},
+				Spec: UserSpec{
+					Name:       "test-user",
+					Mechanism:  "scram-sha-512",
+					Password:   "secure-password-123",
+					Iterations: 8192,
+				},
+			},
+			shouldError: false,
+		},
+		{
+			name: "invalid - empty user name",
+			userConfig: UserConfig{
+				Meta: ResourceMeta{
+					Name:        "test-user",
+					Cluster:     "test-cluster",
+					Region:      "us-west-2",
+					Environment: "dev",
+				},
+				Spec: UserSpec{
+					Name:       "",
+					Mechanism:  "scram-sha-256",
+					Password:   "secure-password-123",
+					Iterations: 4096,
+				},
+			},
+			shouldError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid - empty password",
+			userConfig: UserConfig{
+				Meta: ResourceMeta{
+					Name:        "test-user",
+					Cluster:     "test-cluster",
+					Region:      "us-west-2",
+					Environment: "dev",
+				},
+				Spec: UserSpec{
+					Name:       "test-user",
+					Mechanism:  "scram-sha-256",
+					Password:   "",
+					Iterations: 4096,
+				},
+			},
+			shouldError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid - unsupported mechanism",
+			userConfig: UserConfig{
+				Meta: ResourceMeta{
+					Name:        "test-user",
+					Cluster:     "test-cluster",
+					Region:      "us-west-2",
+					Environment: "dev",
+				},
+				Spec: UserSpec{
+					Name:       "test-user",
+					Mechanism:  "invalid-mechanism",
+					Password:   "secure-password-123",
+					Iterations: 4096,
+				},
+			},
+			shouldError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid - too few iterations",
+			userConfig: UserConfig{
+				Meta: ResourceMeta{
+					Name:        "test-user",
+					Cluster:     "test-cluster",
+					Region:      "us-west-2",
+					Environment: "dev",
+				},
+				Spec: UserSpec{
+					Name:       "test-user",
+					Mechanism:  "scram-sha-256",
+					Password:   "secure-password-123",
+					Iterations: 500,
+				},
+			},
+			shouldError: true,
+			errorCount:  1,
+		},
+		{
+			name: "invalid meta - missing required fields",
+			userConfig: UserConfig{
+				Meta: ResourceMeta{
+					Name: "",
+					// Missing cluster, region, environment
+				},
+				Spec: UserSpec{
+					Name:       "test-user",
+					Mechanism:  "scram-sha-256",
+					Password:   "secure-password-123",
+					Iterations: 4096,
+				},
+			},
+			shouldError: true,
+			errorCount:  4, // name, cluster, region, environment
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.userConfig.Validate()
+			if test.shouldError {
+				assert.Error(t, err)
+				if test.errorCount > 0 {
+					// Check that we have the expected number of errors
+					assert.Contains(t, err.Error(), "error")
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUserConfigSetDefaults(t *testing.T) {
+	userConfig := UserConfig{
+		Meta: ResourceMeta{
+			Name:        "test-user",
+			Cluster:     "test-cluster",
+			Region:      "us-west-2",
+			Environment: "dev",
+		},
+		Spec: UserSpec{
+			Name:     "test-user",
+			Password: "secure-password-123",
+			// Mechanism and Iterations not set - should get defaults
+		},
+	}
+
+	userConfig.SetDefaults()
+
+	assert.Equal(t, "scram-sha-256", userConfig.Spec.Mechanism)
+	assert.Equal(t, 4096, userConfig.Spec.Iterations)
+}
+
+func TestUserConfigToScramMechanism(t *testing.T) {
+	tests := []struct {
+		name      string
+		mechanism string
+		expected  kafka.ScramMechanism
+	}{
+		{
+			name:      "SHA256 lowercase",
+			mechanism: "scram-sha-256",
+			expected:  kafka.ScramMechanismSha256,
+		},
+		{
+			name:      "SHA256 uppercase",
+			mechanism: "SCRAM-SHA-256",
+			expected:  kafka.ScramMechanismSha256,
+		},
+		{
+			name:      "SHA256 with underscores",
+			mechanism: "scram_sha_256",
+			expected:  kafka.ScramMechanismSha256,
+		},
+		{
+			name:      "SHA512 lowercase",
+			mechanism: "scram-sha-512",
+			expected:  kafka.ScramMechanismSha512,
+		},
+		{
+			name:      "SHA512 uppercase",
+			mechanism: "SCRAM-SHA-512",
+			expected:  kafka.ScramMechanismSha512,
+		},
+		{
+			name:      "SHA512 with underscores",
+			mechanism: "scram_sha_512",
+			expected:  kafka.ScramMechanismSha512,
+		},
+		{
+			name:      "unknown mechanism defaults to SHA256",
+			mechanism: "unknown",
+			expected:  kafka.ScramMechanismSha256,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			userConfig := UserConfig{
+				Spec: UserSpec{
+					Mechanism: test.mechanism,
+				},
+			}
+			result := userConfig.ToScramMechanism()
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestLoadUserBytes(t *testing.T) {
+	yamlContent := `
+meta:
+  name: test-user
+  cluster: test-cluster
+  region: us-west-2
+  environment: dev
+spec:
+  name: test-user
+  mechanism: scram-sha-256
+  password: test-password
+  iterations: 4096
+`
+
+	userConfig, err := LoadUserBytes([]byte(yamlContent))
+	assert.NoError(t, err)
+	assert.Equal(t, "test-user", userConfig.Meta.Name)
+	assert.Equal(t, "test-cluster", userConfig.Meta.Cluster)
+	assert.Equal(t, "test-user", userConfig.Spec.Name)
+	assert.Equal(t, "scram-sha-256", userConfig.Spec.Mechanism)
+	assert.Equal(t, "test-password", userConfig.Spec.Password)
+	assert.Equal(t, 4096, userConfig.Spec.Iterations)
+}

--- a/pkg/create/user.go
+++ b/pkg/create/user.go
@@ -1,0 +1,208 @@
+package create
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"errors"
+	"fmt"
+	"hash"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/segmentio/topicctl/pkg/admin"
+	"github.com/segmentio/topicctl/pkg/config"
+	"github.com/segmentio/topicctl/pkg/util"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// UserCreatorConfig contains the configuration for a user creator.
+type UserCreatorConfig struct {
+	ClusterConfig config.ClusterConfig
+	DryRun        bool
+	SkipConfirm   bool
+	UserConfig    config.UserConfig
+}
+
+// UserCreator handles the creation of SCRAM users in Kafka.
+type UserCreator struct {
+	config        UserCreatorConfig
+	adminClient   admin.Client
+	clusterConfig config.ClusterConfig
+	userConfig    config.UserConfig
+}
+
+// NewUserCreator creates a new UserCreator instance.
+func NewUserCreator(
+	ctx context.Context,
+	adminClient admin.Client,
+	creatorConfig UserCreatorConfig,
+) (*UserCreator, error) {
+	// Check if the cluster supports user management
+	supportedFeatures := adminClient.GetSupportedFeatures()
+	if !supportedFeatures.Users {
+		return nil, fmt.Errorf("User management is not supported by this cluster")
+	}
+
+	return &UserCreator{
+		config:        creatorConfig,
+		adminClient:   adminClient,
+		clusterConfig: creatorConfig.ClusterConfig,
+		userConfig:    creatorConfig.UserConfig,
+	}, nil
+}
+
+// Create creates the SCRAM user in the Kafka cluster.
+func (u *UserCreator) Create(ctx context.Context) error {
+	log.Info("Validating configs...")
+
+	if err := u.clusterConfig.Validate(); err != nil {
+		return err
+	}
+
+	if err := u.userConfig.Validate(); err != nil {
+		return err
+	}
+
+	if err := config.CheckConsistency(u.userConfig.Meta, u.clusterConfig); err != nil {
+		return err
+	}
+
+	log.Infof("Checking if user '%s' already exists...", u.userConfig.Spec.Name)
+
+	// Check if user already exists
+	existingUsers, err := u.adminClient.GetUsers(ctx, []string{u.userConfig.Spec.Name})
+	if err != nil {
+		return fmt.Errorf("Error checking for existing user '%s': %v", u.userConfig.Spec.Name, err)
+	}
+
+	userExists := len(existingUsers) > 0
+	if userExists {
+		log.Infof("User '%s' already exists with mechanisms: %+v",
+			u.userConfig.Spec.Name,
+			existingUsers[0].CredentialInfos)
+
+		// Check if the same mechanism already exists
+		targetMechanism := u.userConfig.ToScramMechanism()
+		for _, cred := range existingUsers[0].CredentialInfos {
+			if kafka.ScramMechanism(cred.ScramMechanism) == targetMechanism {
+				log.Infof("User '%s' already has SCRAM credentials for mechanism %s",
+					u.userConfig.Spec.Name, u.userConfig.Spec.Mechanism)
+				return nil
+			}
+		}
+		log.Infof("User '%s' exists but doesn't have credentials for mechanism %s, will add them",
+			u.userConfig.Spec.Name, u.userConfig.Spec.Mechanism)
+	}
+
+	if u.config.DryRun {
+		if userExists {
+			log.Infof("Would add SCRAM-%s credentials to existing user '%s'",
+				u.userConfig.Spec.Mechanism, u.userConfig.Spec.Name)
+		} else {
+			log.Infof("Would create new user '%s' with SCRAM-%s credentials",
+				u.userConfig.Spec.Name, u.userConfig.Spec.Mechanism)
+		}
+		return nil
+	}
+
+	// Generate SCRAM credentials
+	scramCredentials, err := u.generateScramCredentials()
+	if err != nil {
+		return fmt.Errorf("Error generating SCRAM credentials: %v", err)
+	}
+
+	action := "create"
+	if userExists {
+		action = "update"
+	}
+
+	log.Infof("Ready to %s user '%s' with SCRAM-%s credentials (iterations: %d)",
+		action, u.userConfig.Spec.Name, u.userConfig.Spec.Mechanism, u.userConfig.Spec.Iterations)
+
+	ok, _ := util.Confirm("OK to continue?", u.config.SkipConfirm)
+	if !ok {
+		return errors.New("Stopping because of user response")
+	}
+
+	log.Infof("Creating/updating user '%s' with SCRAM-%s credentials...",
+		u.userConfig.Spec.Name, u.userConfig.Spec.Mechanism)
+
+	if err := u.adminClient.UpsertUser(ctx, *scramCredentials); err != nil {
+		return fmt.Errorf("Error creating/updating user '%s': %v", u.userConfig.Spec.Name, err)
+	}
+
+	log.Infof("Successfully created/updated user '%s'", u.userConfig.Spec.Name)
+	return nil
+}
+
+// generateScramCredentials creates the SCRAM credentials for the user.
+func (u *UserCreator) generateScramCredentials() (*kafka.UserScramCredentialsUpsertion, error) {
+	// Generate a random salt
+	salt := make([]byte, 32)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("Failed to generate salt: %v", err)
+	}
+
+	// Get the SCRAM mechanism
+	mechanism := u.userConfig.ToScramMechanism()
+
+	// Generate salted password based on mechanism
+	var saltedPassword []byte
+	var err error
+
+	switch mechanism {
+	case kafka.ScramMechanismSha256:
+		saltedPassword, err = generateSaltedPassword(
+			u.userConfig.Spec.Password,
+			salt,
+			u.userConfig.Spec.Iterations,
+			"sha256",
+		)
+	case kafka.ScramMechanismSha512:
+		saltedPassword, err = generateSaltedPassword(
+			u.userConfig.Spec.Password,
+			salt,
+			u.userConfig.Spec.Iterations,
+			"sha512",
+		)
+	default:
+		return nil, fmt.Errorf("Unsupported SCRAM mechanism: %v", mechanism)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to generate salted password: %v", err)
+	}
+
+	return &kafka.UserScramCredentialsUpsertion{
+		Name:           u.userConfig.Spec.Name,
+		Mechanism:      mechanism,
+		Iterations:     u.userConfig.Spec.Iterations,
+		Salt:           salt,
+		SaltedPassword: saltedPassword,
+	}, nil
+}
+
+// generateSaltedPassword generates a salted password using PBKDF2.
+// This implements the SCRAM authentication mechanism that Kafka expects.
+func generateSaltedPassword(password string, salt []byte, iterations int, hashAlg string) ([]byte, error) {
+	var hashFunc func() hash.Hash
+	var keyLen int
+
+	switch hashAlg {
+	case "sha256":
+		hashFunc = sha256.New
+		keyLen = 32 // SHA-256 output length
+	case "sha512":
+		hashFunc = sha512.New
+		keyLen = 64 // SHA-512 output length
+	default:
+		return nil, fmt.Errorf("unsupported hash algorithm: %s", hashAlg)
+	}
+
+	// Generate salted password using PBKDF2
+	saltedPassword := pbkdf2.Key([]byte(password), salt, iterations, keyLen, hashFunc)
+
+	return saltedPassword, nil
+}


### PR DESCRIPTION
- Add create user subcommand with SCRAM-SHA-256/512 support
- Add user configuration parsing and validation
- Include example user configuration files
- Implement proper SCRAM credential generation with salt
- Change error messages, to look more universal