### PR TITLE
chore: fix Go Module Path (v2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/segmentio/topicctl
+module github.com/segmentio/topicctl/v2
 
 go 1.24.4
 


### PR DESCRIPTION
## Problem

`go install github.com/segmentio/topicctl/cmd/topicctl@latest` installs old version.

```console
$ go install github.com/segmentio/topicctl/cmd/topicctl@latest
go: downloading github.com/segmentio/topicctl v1.23.1
```

`go install github.com/segmentio/topicctl/cmd/topicctl@v2.0.1` fails.

```console
$ go install github.com/segmentio/topicctl/cmd/topicctl@v2.0.1
go: github.com/segmentio/topicctl/cmd/topicctl@v2.0.1: github.com/segmentio/topicctl@v2.0.1: invalid version: module contains a go.mod file, so module path must match major version ("github.com/segmentio/topicctl/v2")
```