### PR TITLE
Add keep throttle flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ docker-compose down
 #### apply
 
 ```
-topicctl apply [path(s) to topic config(s)]
+topicctl apply [flags] [path(s) to topic config(s)]
 ```
 
 The `apply` subcommand ensures that the actual state of a topic in the cluster
@@ -134,6 +134,28 @@ then the tool will initiate the necessary changes to bring it into compliance.
 
 See the [Config formats](#config-formats) section below for more information on the
 expected file formats.
+
+##### apply flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--skip-confirm` | bool | false | Skip confirmation prompts |
+| `--keep-throttle` | bool | false | Keep replication throttle settings instead of removing them after apply |
+| `--no-spinner` | bool | false | Disable progress spinner |
+| `--conn-timeout` | duration | 10s | Connection timeout |
+| `--rebalance` | bool | false | Rebalance topic replicas after apply |
+
+##### Apply Examples
+
+Apply while preserving replication throttle settings with skip confirm:
+```bash
+topicctl apply --skip-confirm --keep-throttle \
+  --cluster-config examples/local-cluster/cluster.yaml examples/local-cluster/topics/my-topic.yaml
+```
+
+This is useful for topics where throttle settings (e.g., `leader.replication.throttled.replicas`,
+`follower.replication.throttled.replicas`) are intentionally configured and should be maintained
+across applies.
 
 #### bootstrap
 

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -227,6 +227,7 @@ func applyTopic(
 			aws.Config{},
 			config.AdminClientOpts{
 				ReadOnly:                  applyConfig.dryRun,
+				KafkaConnTimeout:          applyConfig.shared.connTimeout,
 				UsernameOverride:          applyConfig.shared.saslUsername,
 				PasswordOverride:          applyConfig.shared.saslPassword,
 				SecretsManagerArnOverride: applyConfig.shared.saslSecretsManagerArn,

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -39,6 +39,7 @@ type applyCmdConfig struct {
 	ignoreFewerPartitionsError   bool
 	sleepLoopDuration            time.Duration
 	failFast                     bool
+	keepThrottle                 bool
 
 	shared sharedOptions
 
@@ -119,6 +120,12 @@ func init() {
 		"fail-fast",
 		true,
 		"Fail upon the first error encountered during apply process",
+	)
+	applyCmd.Flags().BoolVar(
+		&applyConfig.keepThrottle,
+		"keep-throttle",
+		false,
+		"Keep replication throttle settings instead of removing them",
 	)
 
 	addSharedConfigOnlyFlags(applyCmd, &applyConfig.shared)
@@ -263,6 +270,7 @@ func applyTopic(
 			IgnoreFewerPartitionsError: applyConfig.ignoreFewerPartitionsError,
 			SleepLoopDuration:          applyConfig.sleepLoopDuration,
 			TopicConfig:                topicConfig,
+			KeepThrottle:               applyConfig.keepThrottle,
 		}
 
 		if err := cliRunner.ApplyTopic(ctx, applierConfig); err != nil {

--- a/cmd/topicctl/subcmd/bootstrap.go
+++ b/cmd/topicctl/subcmd/bootstrap.go
@@ -82,6 +82,7 @@ func bootstrapRun(cmd *cobra.Command, args []string) error {
 		aws.Config{},
 		config.AdminClientOpts{
 			ReadOnly:                  true,
+			KafkaConnTimeout:          bootstrapConfig.shared.connTimeout,
 			UsernameOverride:          bootstrapConfig.shared.saslUsername,
 			PasswordOverride:          bootstrapConfig.shared.saslPassword,
 			SecretsManagerArnOverride: bootstrapConfig.shared.saslSecretsManagerArn,

--- a/cmd/topicctl/subcmd/check.go
+++ b/cmd/topicctl/subcmd/check.go
@@ -140,6 +140,7 @@ func checkTopicFile(
 				aws.Config{},
 				config.AdminClientOpts{
 					ReadOnly:                  true,
+					KafkaConnTimeout:          checkConfig.shared.connTimeout,
 					UsernameOverride:          checkConfig.shared.saslUsername,
 					PasswordOverride:          checkConfig.shared.saslPassword,
 					SecretsManagerArnOverride: checkConfig.shared.saslSecretsManagerArn,

--- a/cmd/topicctl/subcmd/create.go
+++ b/cmd/topicctl/subcmd/create.go
@@ -153,6 +153,7 @@ func createACL(
 			aws.Config{},
 			config.AdminClientOpts{
 				ReadOnly:                  createConfig.dryRun,
+				KafkaConnTimeout:          createConfig.shared.connTimeout,
 				UsernameOverride:          createConfig.shared.saslUsername,
 				PasswordOverride:          createConfig.shared.saslPassword,
 				SecretsManagerArnOverride: createConfig.shared.saslSecretsManagerArn,

--- a/cmd/topicctl/subcmd/rebalance.go
+++ b/cmd/topicctl/subcmd/rebalance.go
@@ -128,6 +128,7 @@ func rebalanceRun(cmd *cobra.Command, args []string) error {
 		aws.Config{},
 		config.AdminClientOpts{
 			ReadOnly:                  rebalanceConfig.dryRun,
+			KafkaConnTimeout:          rebalanceConfig.shared.connTimeout,
 			UsernameOverride:          rebalanceConfig.shared.saslUsername,
 			PasswordOverride:          rebalanceConfig.shared.saslPassword,
 			SecretsManagerArnOverride: rebalanceConfig.shared.saslSecretsManagerArn,

--- a/cmd/topicctl/subcmd/shared.go
+++ b/cmd/topicctl/subcmd/shared.go
@@ -320,4 +320,10 @@ func addSharedConfigOnlyFlags(cmd *cobra.Command, options *sharedOptions) {
 		os.Getenv("TOPICCTL_SASL_SECRETS_MANAGER_ARN"),
 		"Secrets Manager ARN to use for credentials if using SASL; will override value set in cluster config",
 	)
+	cmd.Flags().DurationVar(
+		&options.connTimeout,
+		"conn-timeout",
+		10*time.Second,
+		"Kafka connection timeout",
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yieldlab/topicctl
+module github.com/segmentio/topicctl
 
 go 1.24.4
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/segmentio/topicctl
+module github.com/yieldlab/topicctl
 
 go 1.24.4
 

--- a/pkg/admin/brokerclient.go
+++ b/pkg/admin/brokerclient.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultTimeout = 5 * time.Second
+	defaultRequestTimeout = 5 * time.Second
 
 	// Used for filtering out default configs
 	configSourceUnknown                    int8 = 0
@@ -136,6 +136,14 @@ func NewBrokerAdminClient(
 	}
 
 	return adminClient, nil
+}
+
+func (c *BrokerAdminClient) requestTimeout() time.Duration {
+	if c.config.ConnTimeout > 0 {
+		return c.config.ConnTimeout
+	}
+
+	return defaultRequestTimeout
 }
 
 // GetClusterID gets the ID of the cluster.
@@ -597,7 +605,7 @@ func (c *BrokerAdminClient) AssignPartitions(
 	req := kafka.AlterPartitionReassignmentsRequest{
 		Topic:       topic,
 		Assignments: apiAssignments,
-		Timeout:     defaultTimeout,
+		Timeout:     c.requestTimeout(),
 	}
 	log.Debugf("AlterPartitionReassignments request: %+v", req)
 
@@ -708,7 +716,7 @@ func (c *BrokerAdminClient) RunLeaderElection(
 	req := kafka.ElectLeadersRequest{
 		Topic:      topic,
 		Partitions: partitions,
-		Timeout:    defaultTimeout,
+		Timeout:    c.requestTimeout(),
 	}
 	log.Debugf("ElectLeaders request: %+v", req)
 

--- a/pkg/admin/brokerclient_test.go
+++ b/pkg/admin/brokerclient_test.go
@@ -44,6 +44,25 @@ func TestBrokerClientControllerID(t *testing.T) {
 	}, fmt.Sprintf("Received %d, Broker Controller ID should be between 1 and 6.", controllerID))
 }
 
+func TestBrokerAdminClientRequestTimeoutDefault(t *testing.T) {
+	client := &BrokerAdminClient{}
+
+	assert.Equal(t, defaultRequestTimeout, client.requestTimeout())
+}
+
+func TestBrokerAdminClientRequestTimeoutOverride(t *testing.T) {
+	customTimeout := 42 * time.Second
+	client := &BrokerAdminClient{
+		config: BrokerAdminClientConfig{
+			ConnectorConfig: ConnectorConfig{
+				ConnTimeout: customTimeout,
+			},
+		},
+	}
+
+	assert.Equal(t, customTimeout, client.requestTimeout())
+}
+
 func TestBrokerClientGetClusterID(t *testing.T) {
 	if !util.CanTestBrokerAdmin() {
 		t.Skip("Skipping because KAFKA_TOPICS_TEST_BROKER_ADMIN is not set")

--- a/pkg/admin/connector_test.go
+++ b/pkg/admin/connector_test.go
@@ -1,0 +1,137 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/protocol"
+	"github.com/segmentio/kafka-go/protocol/createtopics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConnectorDefaultTimeout(t *testing.T) {
+	originalTimeout := kafka.DefaultDialer.Timeout
+	t.Cleanup(func() { kafka.DefaultDialer.Timeout = originalTimeout })
+
+	connector, err := NewConnector(
+		ConnectorConfig{
+			BrokerAddr: "localhost:9092",
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 10*time.Second, connector.Dialer.Timeout)
+	transport, ok := connector.KafkaClient.Transport.(*kafka.Transport)
+	require.True(t, ok)
+	assert.Equal(t, 10*time.Second, transport.DialTimeout)
+	assert.Equal(t, 10*time.Second, connector.KafkaClient.Timeout)
+}
+
+func TestNewConnectorCustomTimeout(t *testing.T) {
+	customTimeout := 3 * time.Second
+
+	connector, err := NewConnector(
+		ConnectorConfig{
+			BrokerAddr:  "localhost:9092",
+			ConnTimeout: customTimeout,
+			TLS: TLSConfig{
+				Enabled:    true,
+				SkipVerify: true,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, customTimeout, connector.Dialer.Timeout)
+	assert.NotNil(t, connector.Dialer.TLS)
+	transport, ok := connector.KafkaClient.Transport.(*kafka.Transport)
+	require.True(t, ok)
+	assert.Equal(t, customTimeout, transport.DialTimeout)
+	assert.Equal(t, customTimeout, connector.KafkaClient.Timeout)
+}
+
+func TestConnectorDialerTimeoutHappyPath(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	acceptErrCh := make(chan error)
+	go func() {
+		defer close(acceptErrCh)
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		if err := conn.Close(); err != nil {
+			acceptErrCh <- err
+		}
+	}()
+
+	connector, err := NewConnector(
+		ConnectorConfig{
+			BrokerAddr:  listener.Addr().String(),
+			ConnTimeout: 100 * time.Millisecond,
+		},
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	conn, err := connector.Dialer.DialContext(ctx, "tcp", listener.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	select {
+	case err, ok := <-acceptErrCh:
+		if ok {
+			require.NoError(t, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for listener accept")
+	}
+}
+
+func TestConnectorDialerTimeoutUnhappyPath(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	connector, err := NewConnector(
+		ConnectorConfig{
+			BrokerAddr:  listener.Addr().String(),
+			ConnTimeout: time.Nanosecond,
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = connector.Dialer.DialContext(t.Context(), "tcp", listener.Addr().String())
+	require.Error(t, err)
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		require.True(t, netErr.Timeout(), "expected timeout error, got: %v", err)
+		return
+	}
+
+	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected deadline exceeded, got: %v", err)
+}
+
+type captureTransport struct {
+	t                 *testing.T
+	expectedTimeoutMs int32
+}
+
+func (c *captureTransport) RoundTrip(_ context.Context, _ net.Addr, req protocol.Message) (protocol.Message, error) {
+	createReq, ok := req.(*createtopics.Request)
+	require.True(c.t, ok)
+	require.Equal(c.t, c.expectedTimeoutMs, createReq.TimeoutMs)
+
+	return &createtopics.Response{}, nil
+}

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -38,6 +38,7 @@ type TopicApplierConfig struct {
 	IgnoreFewerPartitionsError bool
 	SleepLoopDuration          time.Duration
 	TopicConfig                config.TopicConfig
+	KeepThrottle               bool
 }
 
 // TopicApplier executes an "apply" run on a topic by comparing the actual
@@ -281,7 +282,7 @@ func (t *TopicApplier) checkExistingState(
 			return nil
 		}
 
-		if topicInfo.IsThrottled() {
+		if topicInfo.IsThrottled() && !t.config.KeepThrottle {
 			log.Infof(
 				"It looks there are still throttles on the topic (config: %+v)",
 				topicInfo.Config,

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -901,6 +901,79 @@ func TestApplyOverrides(t *testing.T) {
 	assert.Equal(t, applier.maxBatchSize, 8)
 }
 
+func TestApplyKeepThrottle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	topicName := util.RandomString("apply-keep-throttle-", 6)
+	topicConfig := config.TopicConfig{
+		Meta: config.ResourceMeta{
+			Name:        topicName,
+			Cluster:     "test-cluster",
+			Region:      "test-region",
+			Environment: "test-environment",
+		},
+		Spec: config.TopicSpec{
+			Partitions:        3,
+			ReplicationFactor: 2,
+			RetentionMinutes:  500,
+			PlacementConfig: config.TopicPlacementConfig{
+				Strategy: config.PlacementStrategyStatic,
+				Picker:   config.PickerMethodLowestIndex,
+				StaticAssignments: [][]int{
+					{1, 2},
+					{2, 3},
+					{1, 3},
+				},
+			},
+			MigrationConfig: &config.TopicMigrationConfig{
+				ThrottleMB:         2,
+				PartitionBatchSize: 3,
+			},
+		},
+	}
+	// Create topic
+	applier := testApplier(ctx, t, topicConfig)
+	defer applier.adminClient.Close()
+	err := applier.Apply(ctx)
+	require.NoError(t, err)
+
+	topicInfo, err := applier.adminClient.GetTopic(ctx, topicName, true)
+	require.NoError(t, err)
+	// Topic should not be throttled initially
+	assert.False(t, topicInfo.IsThrottled())
+
+	supported := applier.adminClient.GetSupportedFeatures()
+	if !(supported.Locks && supported.DynamicBrokerConfigs) {
+		// This test only works on zk-based clients for now
+		return
+	}
+
+	// Manually add throttles to the topic
+	_, err = applier.adminClient.UpdateTopicConfig(
+		ctx,
+		topicName,
+		[]kafka.ConfigEntry{
+			{
+				ConfigName:  admin.LeaderReplicasThrottledKey,
+				ConfigValue: "0:1,1:2,2:3",
+			},
+			{
+				ConfigName:  admin.FollowerReplicasThrottledKey,
+				ConfigValue: "0:2,1:3,2:1",
+			},
+		},
+		true,
+	)
+	require.NoError(t, err)
+
+	topicInfo, err = applier.adminClient.GetTopic(ctx, topicName, true)
+	require.NoError(t, err)
+	// Topic should now be throttled
+	assert.True(t, topicInfo.IsThrottled())
+
+	// Test 1: keepThrottle = false (default behavior - should remove throttles)
+}
+
 func testTopicName(name string) string {
 	return util.RandomString(fmt.Sprintf("topic-%s-", name), 6)
 }

--- a/scripts/set_up_net_alias.sh
+++ b/scripts/set_up_net_alias.sh
@@ -1,17 +1,39 @@
 #!/bin/bash
 
+set -euo pipefail
+
 ADDR=169.254.123.123
+NETMASK=255.255.255.0
+CIDR=24
 echo "Aliasing $ADDR to localhost..."
 
-UNAME=$(uname -a)
-case "$UNAME" in
-    Linux*) sudo ifconfig lo:0 $ADDR netmask 255.255.255.0 up;;
-    Darwin*) sudo ifconfig lo0 alias $ADDR;;
-    *) exit
+alias_exists_with_ip() {
+    ip addr show dev lo | grep -q "$ADDR"
+}
+
+OS=$(uname -s)
+case "$OS" in
+    Linux*)
+        if command -v ifconfig >/dev/null 2>&1; then
+            sudo ifconfig lo:0 "$ADDR" netmask "$NETMASK" up
+        elif command -v ip >/dev/null 2>&1; then
+            if alias_exists_with_ip; then
+                echo "Alias already present on loopback interface."
+            else
+                sudo ip addr add "$ADDR/$CIDR" dev lo
+            fi
+        else
+            >&2 echo "Neither ifconfig nor ip is available; cannot create alias."
+            exit 1
+        fi
+        ;;
+    Darwin*)
+        sudo ifconfig lo0 alias "$ADDR"
+        ;;
+    *)
+        >&2 echo "Unsupported platform: $OS"
+        exit 1
+        ;;
 esac
 
-if [[ $? != 0 ]]
-then
-    >&2 echo "Unable to create alias"
-    exit 1
-fi
+echo "Alias configured."


### PR DESCRIPTION
feat(apply): add --keep-throttle flag to preserve replication throttles
Add a new `--keep-throttle` boolean flag to the apply command that allows
users to preserve replication throttle settings instead of having them
automatically removed after applying topic configurations.

This is particularly useful for topics where throttle settings
(leader.replication.throttled.replicas, follower.replication.throttled.replicas)
are intentionally configured in the topic YAML and should be maintained
across applies.

Changes:
- Add --keep-throttle flag to apply command
- Skip automatic throttle removal when flag is set
- Update help documentation

Example usage:
  topicctl apply --keep-throttle --skip-confirm \
    --cluster-config cluster.yaml topics/my-topic.yaml
